### PR TITLE
fix: Add missing CSS styles for buttons

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -211,6 +211,8 @@ footer {
 .btn-secondary { background-color: var(--secondary-color); }
 .btn-danger { background-color: #dc3545; }
 .btn-success { background-color: #28a745; }
+.btn-warning { background-color: #ffc107; }
+.btn-info { background-color: #17a2b8; }
 
 /* =================================================================
    TABLES & PAGE HEADERS

--- a/views/clientes/list.php
+++ b/views/clientes/list.php
@@ -32,7 +32,6 @@
             <th>Documento</th>
             <th>Email</th>
             <th>Teléfono</th>
-            <!-- Columna de Acciones: Editar y Eliminar -->
             <th>Acciones</th>
         </tr>
     </thead>


### PR DESCRIPTION
The 'Edit' button was not visible on the customer list page because the CSS classes '.btn-warning' and '.btn-info' were not defined in the custom stylesheet.

This commit adds the missing style definitions to `public/assets/css/style.css`, ensuring that buttons using these classes are rendered correctly.