### PR TITLE
Feat(clientes): Añadir validación JS para documento duplicado

### DIFF
--- a/bd/update_v1.12.sql
+++ b/bd/update_v1.12.sql
@@ -1,0 +1,32 @@
+-- =================================================================
+-- Update Script v1.12
+-- Nuevo procedimiento para validación de duplicados en JS
+-- =================================================================
+
+USE `academia_cursos`;
+
+DELIMITER $$
+
+-- -----------------------------------------------------
+-- `sp_cliente_verificar_documento_existente`
+-- Verifica si un número de documento ya existe para otro cliente.
+-- Devuelve 1 si existe, 0 si no.
+-- -----------------------------------------------------
+DROP PROCEDURE IF EXISTS `sp_cliente_verificar_documento_existente`$$
+CREATE PROCEDURE `sp_cliente_verificar_documento_existente`(
+    IN p_numero_documento VARCHAR(20),
+    IN p_id_cliente_excluir INT
+)
+BEGIN
+    SELECT COUNT(id_cliente) as `exists`
+    FROM clientes
+    WHERE
+        numero_documento = p_numero_documento AND
+        (p_id_cliente_excluir IS NULL OR id_cliente != p_id_cliente_excluir);
+END$$
+
+DELIMITER ;
+
+-- =================================================================
+-- Fin del Script v1.12
+-- =================================================================

--- a/controllers/clientes_controller.php
+++ b/controllers/clientes_controller.php
@@ -103,6 +103,21 @@ try {
             }
             break;
 
+        case 'check_documento':
+            // Endpoint para validación AJAX
+            header('Content-Type: application/json');
+            $num_doc = $_GET['numero_documento'] ?? '';
+            $id_excluir = !empty($_GET['id_cliente']) ? (int)$_GET['id_cliente'] : null;
+
+            if (empty($num_doc)) {
+                echo json_encode(['exists' => false]);
+                exit();
+            }
+
+            $exists = $clienteModel->verificarDocumentoExistente($num_doc, $id_excluir);
+            echo json_encode(['exists' => $exists]);
+            exit();
+
         case 'delete':
             if ($id > 0) {
                 // 1. Verificar si el cliente tiene matrículas

--- a/models/ClienteModel.php
+++ b/models/ClienteModel.php
@@ -117,4 +117,16 @@ class ClienteModel {
             return false;
         }
     }
+
+    /**
+     * Verifica si un número de documento ya existe, excluyendo un ID de cliente.
+     * @param string $numero_documento El número de documento a verificar.
+     * @param int|null $id_cliente_excluir El ID del cliente a excluir de la búsqueda.
+     * @return bool True si existe, false si no.
+     */
+    public function verificarDocumentoExistente($numero_documento, $id_cliente_excluir = null) {
+        $this->db->callStoredProcedure('sp_cliente_verificar_documento_existente', [$numero_documento, $id_cliente_excluir]);
+        $result = $this->db->single();
+        return (int)($result['exists'] ?? 0) > 0;
+    }
 }

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -2,4 +2,67 @@
 // Puede ser usado para añadir interactividad global al sitio.
 document.addEventListener('DOMContentLoaded', function() {
     console.log('Sistema de Academia cargado.');
+
+    // --- Validación de Número de Documento Duplicado para Clientes ---
+    const clienteForm = document.getElementById('cliente-form');
+
+    if (clienteForm) {
+        const numeroDocumentoInput = document.getElementById('numero_documento');
+        const idClienteInput = document.getElementById('id_cliente');
+        const errorDiv = document.getElementById('documento-error');
+        const submitBtn = document.getElementById('submit-btn');
+        let isDocumentoDuplicado = false;
+        const originalDocumento = numeroDocumentoInput.value;
+
+        const checkDocumento = async () => {
+            const numeroDocumento = numeroDocumentoInput.value.trim();
+            const idCliente = idClienteInput ? idClienteInput.value : null;
+
+            // Si el campo está vacío o no ha cambiado (en modo edición), no hacer nada
+            if (!numeroDocumento || (idCliente && numeroDocumento === originalDocumento)) {
+                errorDiv.style.display = 'none';
+                submitBtn.disabled = false;
+                isDocumentoDuplicado = false;
+                return;
+            }
+
+            // Construir la URL para la validación
+            let url = `index.php?view=clientes&action=check_documento&numero_documento=${encodeURIComponent(numeroDocumento)}`;
+            if (idCliente) {
+                url += `&id_cliente=${idCliente}`;
+            }
+
+            try {
+                const response = await fetch(url);
+                const data = await response.json();
+
+                if (data.exists) {
+                    errorDiv.textContent = 'Este número de documento ya está registrado.';
+                    errorDiv.style.display = 'block';
+                    submitBtn.disabled = true;
+                    isDocumentoDuplicado = true;
+                } else {
+                    errorDiv.style.display = 'none';
+                    submitBtn.disabled = false;
+                    isDocumentoDuplicado = false;
+                }
+            } catch (error) {
+                console.error('Error en la validación:', error);
+                // En caso de error de red, permitir el envío para que valide el backend
+                submitBtn.disabled = false;
+                isDocumentoDuplicado = false;
+            }
+        };
+
+        // Validar cuando el usuario deja el campo
+        numeroDocumentoInput.addEventListener('blur', checkDocumento);
+
+        // Prevenir el envío del formulario si hay un error
+        clienteForm.addEventListener('submit', function(e) {
+            if (isDocumentoDuplicado) {
+                e.preventDefault();
+                alert('No se puede guardar. El número de documento ya existe.');
+            }
+        });
+    }
 });

--- a/views/clientes/form.php
+++ b/views/clientes/form.php
@@ -17,10 +17,10 @@ $action_url = $is_edit ? 'index.php?view=clientes&action=update' : 'index.php?vi
 <?php endif; ?>
 
 <div class="form-container">
-    <form action="<?php echo $action_url; ?>" method="POST">
+    <form id="cliente-form" action="<?php echo $action_url; ?>" method="POST">
 
         <?php if ($is_edit): ?>
-            <input type="hidden" name="id_cliente" value="<?php echo $cliente_a_editar['id_cliente']; ?>">
+            <input type="hidden" id="id_cliente" name="id_cliente" value="<?php echo $cliente_a_editar['id_cliente']; ?>">
         <?php endif; ?>
 
         <div class="form-row">
@@ -50,6 +50,7 @@ $action_url = $is_edit ? 'index.php?view=clientes&action=update' : 'index.php?vi
             <div class="form-group">
                 <label for="numero_documento">Número de Documento:</label>
                 <input type="text" id="numero_documento" name="numero_documento" value="<?php echo htmlspecialchars($cliente_a_editar['numero_documento'] ?? ''); ?>" required>
+                <div id="documento-error" class="validation-error" style="display: none; color: red; font-size: 0.9em;"></div>
             </div>
         </div>
 
@@ -70,7 +71,7 @@ $action_url = $is_edit ? 'index.php?view=clientes&action=update' : 'index.php?vi
 
         <div class="form-actions">
             <a href="index.php?view=clientes" class="btn btn-secondary">Cancelar</a>
-            <button type="submit" class="btn btn-primary"><?php echo $is_edit ? 'Actualizar Cliente' : 'Crear Cliente'; ?></button>
+            <button type="submit" id="submit-btn" class="btn btn-primary"><?php echo $is_edit ? 'Actualizar Cliente' : 'Crear Cliente'; ?></button>
         </div>
     </form>
 </div>


### PR DESCRIPTION
Se implementa una validación en tiempo real en el formulario de clientes para verificar si el número de documento ya existe en la base de datos antes de enviar el formulario.

Cambios:
- **Backend**:
  - Se añade el stored procedure `sp_cliente_verificar_documento_existente` para buscar un número de documento, excluyendo opcionalmente el ID del cliente actual.
  - Se añade un nuevo método `verificarDocumentoExistente` en `ClienteModel.php`.
  - Se crea un nuevo endpoint `check_documento` en `clientes_controller.php` que devuelve una respuesta JSON.

- **Frontend**:
  - Se modifica `views/clientes/form.php` para añadir IDs a los elementos del formulario y un contenedor para el mensaje de error.
  - Se añade código a `public/assets/js/main.js` que:
    - Escucha el evento `blur` en el campo del número de documento.
    - Realiza una llamada `fetch` al nuevo endpoint.
    - Muestra un mensaje de error y deshabilita el botón de envío si el documento ya existe.
    - Previene el envío del formulario si la validación ha fallado.