### PR TITLE
Refactor user maintenance page to match application standard

### DIFF
--- a/controllers/usuarios_controller.php
+++ b/controllers/usuarios_controller.php
@@ -1,36 +1,43 @@
 <?php
 
 // =================================================================
-// Controlador para el Mantenimiento de Usuarios
+// Controlador para el Mantenimiento de Usuarios (Refactorizado)
 // =================================================================
 
-// Se asume que `index.php` ya ha cargado `config.php` y `core/Session.php`
 require_once 'models/UsuarioModel.php';
 
 // --- Verificación de Seguridad ---
-// Solo los administradores pueden acceder a esta sección.
-// La clase Session ya debería estar disponible.
+Session::check();
 if (!Session::isAdmin()) {
-    // Si no es admin, redirigir al dashboard o mostrar un error.
     echo "<h1>Acceso Denegado</h1><p>No tienes permiso para acceder a esta página.</p>";
-    // Opcional: header('Location: index.php?view=dashboard');
     exit();
 }
 // ---------------------------------
 
-
 $usuarioModel = new UsuarioModel();
 
-// --- Lógica para manejar acciones (Crear, Actualizar, Eliminar) ---
-$action = $_POST['action'] ?? $_GET['action'] ?? 'list';
-$id = (int)($_POST['id_usuario'] ?? $_GET['id_usuario'] ?? 0);
-$feedback_message = ''; // Para mensajes de éxito o error.
+// --- Gestión de la Acción ---
+$action = $_GET['action'] ?? 'list';
+$id = (int)($_GET['id'] ?? 0);
+
+// --- Variables para la Vistas ---
+$feedback_message = $_SESSION['feedback_message'] ?? null;
+unset($_SESSION['feedback_message']); // Limpiar mensaje
+
+$error_message = '';
+$usuarios = [];
+$usuario_a_editar = null;
 
 try {
     switch ($action) {
         case 'create':
-            // Lógica para crear un nuevo usuario desde un formulario POST
             if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                if (empty($_POST['password'])) {
+                     $_SESSION['feedback_message'] = "Error: La contraseña es obligatoria para crear un usuario.";
+                     header('Location: index.php?view=usuarios&action=new');
+                     exit();
+                }
+
                 $password_hash = password_hash($_POST['password'], PASSWORD_DEFAULT);
                 $datos = [
                     'id_rol' => $_POST['id_rol'],
@@ -39,53 +46,99 @@ try {
                     'email' => $_POST['email'],
                     'nombre_completo' => $_POST['nombre_completo']
                 ];
-                $usuarioModel->crear($datos);
-                $feedback_message = "Usuario creado exitosamente.";
+                $resultado = $usuarioModel->crear($datos);
+                if ($resultado) {
+                    $_SESSION['feedback_message'] = "Usuario creado exitosamente.";
+                } else {
+                    $_SESSION['feedback_message'] = "Error al crear el usuario.";
+                }
+                header('Location: index.php?view=usuarios');
+                exit();
             }
-            break;
+            header('Location: index.php?view=usuarios&action=new');
+            exit();
 
         case 'update':
-            // Lógica para actualizar un usuario desde un formulario POST
-            if ($_SERVER['REQUEST_METHOD'] === 'POST' && $id > 0) {
+            if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                $id_usuario = (int)($_POST['id_usuario'] ?? 0);
+                if ($id_usuario <= 0) {
+                    $_SESSION['feedback_message'] = "Error: ID de usuario no válido.";
+                    header('Location: index.php?view=usuarios');
+                    exit();
+                }
+
                 $datos = [
-                    'id_usuario' => $id,
+                    'id_usuario' => $id_usuario,
                     'id_rol' => $_POST['id_rol'],
                     'nombre_usuario' => $_POST['nombre_usuario'],
                     'email' => $_POST['email'],
                     'nombre_completo' => $_POST['nombre_completo'],
                     'activo' => $_POST['activo'] ?? 0
                 ];
-                $usuarioModel->actualizar($datos);
-                $feedback_message = "Usuario actualizado exitosamente.";
+
+                if (!empty($_POST['password'])) {
+                    $datos['password_hash'] = password_hash($_POST['password'], PASSWORD_DEFAULT);
+                }
+
+                $resultado = $usuarioModel->actualizar($datos);
+
+                if ($resultado) {
+                    $_SESSION['feedback_message'] = "Usuario actualizado exitosamente.";
+                } else {
+                    $_SESSION['feedback_message'] = "Error al actualizar el usuario o no se realizaron cambios.";
+                }
+                header('Location: index.php?view=usuarios');
+                exit();
             }
-            break;
+            header('Location: index.php?view=usuarios');
+            exit();
 
         case 'delete':
-            // Lógica para eliminar (lógicamente) un usuario
             if ($id > 0) {
-                $usuarioModel->eliminar($id);
-                $feedback_message = "Usuario desactivado exitosamente.";
+                if ($id === (int)$_SESSION['user_id']) {
+                     $_SESSION['feedback_message'] = "Error: No puedes desactivar tu propia cuenta.";
+                } else {
+                    if ($usuarioModel->eliminar($id)) {
+                        $_SESSION['feedback_message'] = "Usuario desactivado exitosamente.";
+                    } else {
+                        $_SESSION['feedback_message'] = "Error: No se pudo desactivar el usuario.";
+                    }
+                }
+            } else {
+                $_SESSION['feedback_message'] = "Error: ID de usuario no válido.";
+            }
+            header('Location: index.php?view=usuarios');
+            exit();
+
+        case 'new':
+            require_once 'views/usuarios/form.php';
+            break;
+
+        case 'edit':
+            if ($id > 0) {
+                $usuario_a_editar = $usuarioModel->obtenerPorId($id);
+                if (!$usuario_a_editar) {
+                    $_SESSION['feedback_message'] = "Error: Usuario no encontrado.";
+                    header('Location: index.php?view=usuarios');
+                    exit();
+                }
+                require_once 'views/usuarios/form.php';
+            } else {
+                 $_SESSION['feedback_message'] = "Error: ID de usuario no válido.";
+                 header('Location: index.php?view=usuarios');
+                 exit();
             }
             break;
+
+        case 'list':
+        default:
+            $usuarios = $usuarioModel->obtenerTodos();
+            require_once 'views/usuarios/list.php';
+            break;
     }
+
 } catch (Exception $e) {
-    // En un caso real, loguearíamos el error.
-    $feedback_message = "Error: " . $e->getMessage();
+    $_SESSION['feedback_message'] = "Error inesperado en el sistema: " . $e->getMessage();
+    header('Location: index.php?view=usuarios');
+    exit();
 }
-
-
-// --- Obtención de datos para la vista ---
-
-// Obtener la lista de todos los usuarios para mostrarla en la tabla
-$usuarios = $usuarioModel->obtenerTodos();
-
-// Si la acción es 'edit', obtener los datos del usuario específico para el formulario
-$usuario_a_editar = null;
-if ($action === 'edit' && $id > 0) {
-    $usuario_a_editar = $usuarioModel->obtenerPorId($id);
-}
-
-
-// --- Cargar la Vista ---
-// Finalmente, incluimos el archivo de la vista que mostrará los datos.
-require_once 'views/usuarios_view.php';

--- a/views/usuarios/form.php
+++ b/views/usuarios/form.php
@@ -1,25 +1,20 @@
 <?php require_once 'views/partials/header.php'; ?>
 
 <div class="page-header">
-    <h1>Mantenimiento de Usuarios</h1>
+    <h1><?php echo isset($usuario_a_editar) ? 'Editar Usuario' : 'Crear Nuevo Usuario'; ?></h1>
 </div>
 
-<?php if (!empty($feedback_message)): ?>
-    <div class="info-message">
-        <?php echo htmlspecialchars($feedback_message); ?>
+<?php if (!empty($error_message)): ?>
+    <div class="error-message">
+        <?php echo htmlspecialchars($error_message); ?>
     </div>
 <?php endif; ?>
 
-<!-- Formulario para Crear o Editar Usuarios -->
 <div class="form-container">
-    <h2><?php echo isset($usuario_a_editar) ? 'Editar Usuario' : 'Crear Nuevo Usuario'; ?></h2>
-    <form action="index.php?view=usuarios" method="POST">
+    <form action="index.php?view=usuarios&action=<?php echo isset($usuario_a_editar) ? 'update' : 'create'; ?>" method="POST">
 
         <?php if (isset($usuario_a_editar)): ?>
-            <input type="hidden" name="action" value="update">
             <input type="hidden" name="id_usuario" value="<?php echo $usuario_a_editar['id_usuario']; ?>">
-        <?php else: ?>
-            <input type="hidden" name="action" value="create">
         <?php endif; ?>
 
         <div class="form-row">
@@ -63,52 +58,10 @@
         </div>
 
         <div class="form-actions">
-            <?php if (isset($usuario_a_editar)): ?>
-                <a href="index.php?view=usuarios" class="btn btn-secondary">Cancelar</a>
-            <?php endif; ?>
+            <a href="index.php?view=usuarios" class="btn btn-secondary">Cancelar</a>
             <button type="submit" class="btn btn-primary"><?php echo isset($usuario_a_editar) ? 'Actualizar Usuario' : 'Crear Usuario'; ?></button>
         </div>
     </form>
 </div>
-
-<!-- Tabla con la lista de usuarios -->
-<h2>Lista de Usuarios</h2>
-<table class="table">
-    <thead>
-        <tr>
-            <th>ID</th>
-            <th>Nombre Completo</th>
-            <th>Usuario</th>
-            <th>Email</th>
-            <th>Rol</th>
-            <th>Estado</th>
-            <th>Acciones</th>
-        </tr>
-    </thead>
-    <tbody>
-        <?php foreach ($usuarios as $usuario): ?>
-            <tr>
-                <td><?php echo $usuario['id_usuario']; ?></td>
-                <td><?php echo htmlspecialchars($usuario['nombre_completo']); ?></td>
-                <td><?php echo htmlspecialchars($usuario['nombre_usuario']); ?></td>
-                <td><?php echo htmlspecialchars($usuario['email']); ?></td>
-                <td><?php echo htmlspecialchars($usuario['nombre_rol']); ?></td>
-                <td>
-                    <?php if ($usuario['activo']): ?>
-                        <span class="badge status-activo">Activo</span>
-                    <?php else: ?>
-                        <span class="badge status-inactivo">Inactivo</span>
-                    <?php endif; ?>
-                </td>
-                <td>
-                    <a href="index.php?view=usuarios&action=edit&id_usuario=<?php echo $usuario['id_usuario']; ?>" class="btn btn-warning">Editar</a>
-                    <form action="index.php?view=usuarios&action=delete&id_usuario=<?php echo $usuario['id_usuario']; ?>" method="POST" style="display:inline;" onsubmit="return confirm('¿Está seguro de que desea desactivar este usuario?');">
-                        <button type="submit" class="btn btn-danger">Desactivar</button>
-                    </form>
-                </td>
-            </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
 
 <?php require_once 'views/partials/footer.php'; ?>

--- a/views/usuarios/list.php
+++ b/views/usuarios/list.php
@@ -1,0 +1,60 @@
+<?php require_once 'views/partials/header.php'; ?>
+
+<div class="page-header">
+    <div class="page-header-left">
+        <h1>Mantenimiento de Usuarios</h1>
+    </div>
+    <div class="page-header-right">
+        <a href="index.php?view=usuarios&action=new" class="btn btn-primary">Nuevo Usuario</a>
+    </div>
+</div>
+
+<?php if (!empty($feedback_message)): ?>
+    <div class="info-message <?php echo strpos($feedback_message, 'Error') === 0 ? 'error-message' : ''; ?>">
+        <?php echo htmlspecialchars($feedback_message); ?>
+    </div>
+<?php endif; ?>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Nombre Completo</th>
+            <th>Usuario</th>
+            <th>Email</th>
+            <th>Rol</th>
+            <th>Estado</th>
+            <th>Acciones</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php if (empty($usuarios)): ?>
+            <tr>
+                <td colspan="7">No se encontraron usuarios.</td>
+            </tr>
+        <?php else: ?>
+            <?php foreach ($usuarios as $usuario): ?>
+                <tr>
+                    <td><?php echo $usuario['id_usuario']; ?></td>
+                    <td><?php echo htmlspecialchars($usuario['nombre_completo']); ?></td>
+                    <td><?php echo htmlspecialchars($usuario['nombre_usuario']); ?></td>
+                    <td><?php echo htmlspecialchars($usuario['email']); ?></td>
+                    <td><?php echo htmlspecialchars($usuario['nombre_rol']); ?></td>
+                    <td>
+                        <?php if ($usuario['activo']): ?>
+                            <span class="badge status-activo">Activo</span>
+                    <?php else: ?>
+                            <span class="badge status-inactivo">Inactivo</span>
+                        <?php endif; ?>
+                    </td>
+                    <td>
+                        <a href="index.php?view=usuarios&action=edit&id=<?php echo $usuario['id_usuario']; ?>" class="btn btn-warning">Editar</a>
+                        <a href="index.php?view=usuarios&action=delete&id=<?php echo $usuario['id_usuario']; ?>" class="btn btn-danger" onclick="return confirm('¿Está seguro de que desea desactivar este usuario?');">Desactivar</a>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        <?php endif; ?>
+    </tbody>
+</table>
+
+<?php require_once 'views/partials/footer.php'; ?>


### PR DESCRIPTION
Refactored the "Mantenimiento de Usuarios" page to follow the same standard as other maintenance modules like "Clientes" and "Cursos".

- The monolithic `views/usuarios_view.php` was split into `views/usuarios/list.php` and `views/usuarios/form.php`.
- The `controllers/usuarios_controller.php` was refactored to be action-based, handling 'list', 'new', 'create', 'edit', 'update', and 'delete' actions.
- The controller now correctly loads the separate list and form views.
- The controller now uses session-based feedback messages for better user experience after redirects.
- Improved error handling in the controller by checking the return values from the model.
- Fixed a minor PHP syntax error in the new `list.php`.