### PR TITLE
Fix page layout for New Enrollment form

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -259,3 +259,72 @@ footer {
     max-width: 400px;
     width: 100%;
 }
+
+/* =================================================================
+   MATRICULA PAGE SPECIFIC STYLES
+   ================================================================= */
+.matricula-container {
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.section {
+    background-color: var(--card-bg);
+    border: 1px solid var(--border-color);
+    padding: 2rem;
+    margin-bottom: 2rem;
+    border-radius: 8px;
+    box-shadow: var(--shadow-sm);
+}
+
+.section h2 {
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+}
+
+#cursos-disponibles-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 15px;
+    margin-top: 15px;
+    max-height: 400px;
+    overflow-y: auto;
+    padding: 1rem;
+    background: var(--light-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+}
+
+.curso-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    padding: 1rem;
+    width: 280px;
+    border-radius: 4px;
+    box-shadow: var(--shadow-sm);
+}
+
+#cursos-seleccionados-grid table {
+    width: 100%;
+    margin-top: 1.5rem;
+}
+
+/* Usamos las clases de tabla existentes para consistencia */
+#cursos-seleccionados-grid th,
+#cursos-seleccionados-grid td {
+    padding: 12px;
+    text-align: left;
+}
+
+.total-row {
+    font-weight: bold;
+    text-align: right;
+}

--- a/views/matricula_nueva_view.php
+++ b/views/matricula_nueva_view.php
@@ -1,137 +1,106 @@
-<?php
-// =================================================================
-// Vista para el Formulario de Nueva Matrícula
-// =================================================================
-?>
+<?php require_once 'views/partials/header.php'; ?>
 
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Nueva Matrícula - <?php echo SITE_NAME; ?></title>
-    <style>
-        body { font-family: sans-serif; }
-        .matricula-container { max-width: 1200px; margin: auto; }
-        .section { border: 1px solid #ccc; padding: 20px; margin-bottom: 20px; border-radius: 8px; }
-        .section h2 { margin-top: 0; }
-        .form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; }
-        .form-group { display: flex; flex-direction: column; }
-        label { font-weight: bold; margin-bottom: 5px; }
-        input, select, textarea { padding: 8px; border: 1px solid #ddd; border-radius: 4px; }
-        button { padding: 10px 15px; background-color: #007bff; color: white; border: none; border-radius: 5px; cursor: pointer; }
-        button:hover { background-color: #0056b3; }
-        #cursos-disponibles-container { display: flex; flex-wrap: wrap; gap: 15px; margin-top: 15px; max-height: 400px; overflow-y: auto; padding: 10px; background: #f9f9f9; }
-        .curso-card { background: #fff; border: 1px solid #ddd; padding: 10px; width: 280px; }
-        #cursos-seleccionados-grid table { width: 100%; border-collapse: collapse; margin-top: 15px; }
-        #cursos-seleccionados-grid th, #cursos-seleccionados-grid td { border: 1px solid #ddd; padding: 8px; }
-        .total-row { font-weight: bold; text-align: right; }
-    </style>
-</head>
-<body>
+<div class="matricula-container">
+    <h1>Nueva Matrícula</h1>
+    <form id="form-matricula" action="index.php?view=matriculas" method="POST">
+        <input type="hidden" name="action" value="registrar_matricula">
 
-    <div class="matricula-container">
-        <h1>Nueva Matrícula</h1>
-        <form id="form-matricula" action="index.php?view=matriculas" method="POST">
-            <input type="hidden" name="action" value="registrar_matricula">
-
-            <!-- ======================= SECCIÓN 1: ALUMNO ======================= -->
-            <div class="section">
-                <h2>1. Datos del Alumno</h2>
-                <div class="form-group">
-                    <label for="buscar-cliente">Buscar Alumno (por nombre, apellidos o documento):</label>
-                    <input type="text" id="buscar-cliente" placeholder="Escriba para buscar...">
-                    <input type="hidden" id="id_cliente" name="id_cliente" required>
-                    <div id="cliente-seleccionado-info" style="margin-top:10px; font-weight:bold;"></div>
-                </div>
-                <!-- El botón para crear cliente nuevo se puede añadir aquí -->
+        <!-- ======================= SECCIÓN 1: ALUMNO ======================= -->
+        <div class="section">
+            <h2>1. Datos del Alumno</h2>
+            <div class="form-group">
+                <label for="buscar-cliente">Buscar Alumno (por nombre, apellidos o documento):</label>
+                <input type="text" id="buscar-cliente" placeholder="Escriba para buscar...">
+                <input type="hidden" id="id_cliente" name="id_cliente" required>
+                <div id="cliente-seleccionado-info" style="margin-top:10px; font-weight:bold;"></div>
             </div>
+        </div>
 
-            <!-- ======================= SECCIÓN 2: CURSOS ======================= -->
-            <div class="section">
-                <h2>2. Selección de Cursos</h2>
-                <fieldset>
-                    <legend>Filtros de Búsqueda de Cursos</legend>
-                    <div class="form-grid">
-                        <div class="form-group">
-                            <label for="filtro-profesor">Profesor:</label>
-                            <input type="text" id="filtro-profesor">
-                        </div>
-                        <div class="form-group">
-                            <label for="filtro-fecha-inicio">Desde:</label>
-                            <input type="date" id="filtro-fecha-inicio">
-                        </div>
-                        <div class="form-group">
-                            <label for="filtro-fecha-fin">Hasta:</label>
-                            <input type="date" id="filtro-fecha-fin">
-                        </div>
-                        <div class="form-group" style="align-self: flex-end;">
-                            <button type="button" id="btn-buscar-cursos">Buscar Cursos</button>
-                        </div>
-                    </div>
-                </fieldset>
-
-                <div id="cursos-disponibles-container">
-                    <p>Los cursos disponibles aparecerán aquí...</p>
-                </div>
-
-                <h3>Cursos Agregados a la Matrícula</h3>
-                <div id="cursos-seleccionados-grid">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Curso</th>
-                                <th>Precio Orig.</th>
-                                <th>Precio Pactado</th>
-                                <th>Descuento</th>
-                                <th>Precio Final</th>
-                                <th>Acción</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <!-- Las filas de cursos se añadirán aquí con JS -->
-                        </tbody>
-                        <tfoot>
-                            <tr>
-                                <td colspan="4" class="total-row">TOTAL:</td>
-                                <td id="total-matricula" class="total-row">S/ 0.00</td>
-                                <td></td>
-                            </tr>
-                        </tfoot>
-                    </table>
-                </div>
-            </div>
-
-            <!-- ======================= SECCIÓN 3: PAGO ======================= -->
-            <div class="section">
-                <h2>3. Datos del Pago</h2>
+        <!-- ======================= SECCIÓN 2: CURSOS ======================= -->
+        <div class="section">
+            <h2>2. Selección de Cursos</h2>
+            <fieldset>
+                <legend>Filtros de Búsqueda de Cursos</legend>
                 <div class="form-grid">
                     <div class="form-group">
-                        <label for="fecha_inicio_matricula">Fecha Inicio Matrícula:</label>
-                        <input type="date" id="fecha_inicio_matricula" name="fecha_inicio_matricula" readonly>
+                        <label for="filtro-profesor">Profesor:</label>
+                        <input type="text" id="filtro-profesor">
                     </div>
                     <div class="form-group">
-                        <label for="fecha_fin_matricula">Fecha Fin Matrícula:</label>
-                        <input type="date" id="fecha_fin_matricula" name="fecha_fin_matricula" readonly>
+                        <label for="filtro-fecha-inicio">Desde:</label>
+                        <input type="date" id="filtro-fecha-inicio">
                     </div>
                     <div class="form-group">
-                        <label for="id_forma_pago">Forma de Pago:</label>
-                        <select id="id_forma_pago" name="id_forma_pago" required>
-                            <!-- Opciones cargadas desde BD -->
-                            <option value="1">Efectivo</option>
-                            <option value="2">Tarjeta de Crédito/Débito</option>
-                        </select>
+                        <label for="filtro-fecha-fin">Hasta:</label>
+                        <input type="date" id="filtro-fecha-fin">
+                    </div>
+                    <div class="form-group" style="align-self: flex-end;">
+                        <button type="button" id="btn-buscar-cursos" class="btn">Buscar Cursos</button>
                     </div>
                 </div>
-                <div class="form-group" style="margin-top: 15px;">
-                    <label for="observaciones">Observaciones:</label>
-                    <textarea id="observaciones" name="observaciones" rows="3"></textarea>
-                </div>
+            </fieldset>
+
+            <div id="cursos-disponibles-container">
+                <p>Los cursos disponibles aparecerán aquí...</p>
             </div>
 
-            <button type="submit" style="width: 100%; padding: 15px; font-size: 1.2em; background-color: #28a745;">Registrar Matrícula</button>
-        </form>
-    </div>
+            <h3>Cursos Agregados a la Matrícula</h3>
+            <div id="cursos-seleccionados-grid">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Curso</th>
+                            <th>Precio Orig.</th>
+                            <th>Precio Pactado</th>
+                            <th>Descuento</th>
+                            <th>Precio Final</th>
+                            <th>Acción</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <!-- Las filas de cursos se añadirán aquí con JS -->
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <td colspan="4" class="total-row">TOTAL:</td>
+                            <td id="total-matricula" class="total-row">S/ 0.00</td>
+                            <td></td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+        </div>
+
+        <!-- ======================= SECCIÓN 3: PAGO ======================= -->
+        <div class="section">
+            <h2>3. Datos del Pago</h2>
+            <div class="form-grid">
+                <div class="form-group">
+                    <label for="fecha_inicio_matricula">Fecha Inicio Matrícula:</label>
+                    <input type="date" id="fecha_inicio_matricula" name="fecha_inicio_matricula" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="fecha_fin_matricula">Fecha Fin Matrícula:</label>
+                    <input type="date" id="fecha_fin_matricula" name="fecha_fin_matricula" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="id_forma_pago">Forma de Pago:</label>
+                    <select id="id_forma_pago" name="id_forma_pago" required>
+                        <!-- Opciones cargadas desde BD -->
+                        <option value="1">Efectivo</option>
+                        <option value="2">Tarjeta de Crédito/Débito</option>
+                    </select>
+                </div>
+            </div>
+            <div class="form-group" style="margin-top: 15px;">
+                <label for="observaciones">Observaciones:</label>
+                <textarea id="observaciones" name="observaciones" rows="3"></textarea>
+            </div>
+        </div>
+
+        <button type="submit" class="btn btn-success" style="width: 100%; padding: 15px; font-size: 1.2em;">Registrar Matrícula</button>
+    </form>
+</div>
 
 <script>
 // =================================================================
@@ -249,5 +218,4 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 
-</body>
-</html>
+<?php require_once 'views/partials/footer.php'; ?>


### PR DESCRIPTION
The "Nueva Matrícula" (New Enrollment) page was not rendering with the standard site layout (header, menu, footer) because its view file was a standalone HTML document.

- Refactored `views/matricula_nueva_view.php` to remove the HTML boilerplate and include the standard `header.php` and `footer.php` partials.
- Moved the page-specific CSS from an inline `<style>` block in the view to the main stylesheet `public/assets/css/style.css`.
- Adapted the moved CSS to use the application's existing color and style variables for a consistent look and feel.