### PR TITLE
feat: Format location dropdown in course scheduling page

### DIFF
--- a/controllers/programar_horarios_controller.php
+++ b/controllers/programar_horarios_controller.php
@@ -57,8 +57,16 @@ if ($action === 'programar') {
 $listas_formulario = $programacionModel->obtenerListasParaFormulario();
 $cursos = $listas_formulario['cursos'];
 $profesores = $listas_formulario['profesores'];
-$sub_areas = $listas_formulario['sub_areas'];
+$sub_areas_raw = $listas_formulario['sub_areas'];
 $tipos_horario = $listas_formulario['tipos_horario'];
+
+// Formatear el nombre de la ubicación como lo solicita el usuario
+$sub_areas = [];
+foreach ($sub_areas_raw as $sub_area) {
+    $sub_area['nombre_completo'] = $sub_area['area_nombre'] . ' - ' . $sub_area['descripcion'] . ' ' . $sub_area['numero_sub_area'];
+    $sub_areas[] = $sub_area;
+}
+
 
 // --- Cargar la Vista ---
 require_once 'views/programar_horarios_view.php';

--- a/models/ProgramacionModel.php
+++ b/models/ProgramacionModel.php
@@ -57,7 +57,7 @@ class ProgramacionModel {
         $this->db->callStoredProcedure('sp_profesores_listar_simple');
         $listas['profesores'] = $this->db->resultSet();
 
-        $this->db->callStoredProcedure('sp_sub_areas_listar_simple');
+        $this->db->callStoredProcedure('sp_sub_areas_listar');
         $listas['sub_areas'] = $this->db->resultSet();
 
         $this->db->callStoredProcedure('sp_tipos_horario_listar_simple');


### PR DESCRIPTION
Updated the "Programar Nuevo Curso" page to display the location dropdown options in the format "Area - Subarea Código de Sub Área", as requested by the user.

- Modified `models/ProgramacionModel.php` to call an existing, more detailed stored procedure (`sp_sub_areas_listar`).
- Added logic to `controllers/programar_horarios_controller.php` to loop through the location data and format the display string correctly before passing it to the view.