### PR TITLE
fix: Use explicit COLLATE to fix SQL collation error

### DIFF
--- a/bd/stored_procedures_asistencia.sql
+++ b/bd/stored_procedures_asistencia.sql
@@ -31,8 +31,8 @@ BEGIN
     WHILE v_fecha_actual <= v_fecha_fin DO
         -- DAYOFWEEK devuelve 1 para Domingo, 2 para Lunes, etc.
         -- Se inserta si el día de la semana está en la cadena de días permitidos
-        -- Se usa CAST para evitar errores de collation
-        IF FIND_IN_SET(CAST(DAYOFWEEK(v_fecha_actual) AS CHAR), v_dias_semana) THEN
+        -- Se usa COLLATE para forzar la codificación correcta y evitar errores
+        IF FIND_IN_SET(DAYOFWEEK(v_fecha_actual), v_dias_semana COLLATE utf8mb4_unicode_ci) THEN
             INSERT INTO asistencia_profesor (id_curso_programado, id_profesor, fecha_clase, estado)
             VALUES (p_id_curso_programado, v_id_profesor, v_fecha_actual, 'Programado');
         END IF;


### PR DESCRIPTION
Replaced the `CAST` approach with a more explicit `COLLATE utf8mb4_unicode_ci` clause in the `FIND_IN_SET` function within the `sp_asistencia_profesor_generar_cronograma` stored procedure.

This is a second attempt to fix the "Illegal mix of collations" error reported by the user, as the `CAST` function was not sufficient in their environment.