### PR TITLE
feat: Add schedule conflict validation for professors

### DIFF
--- a/bd/stored_procedures_programacion.sql
+++ b/bd/stored_procedures_programacion.sql
@@ -90,4 +90,28 @@ BEGIN
 END$$
 
 
+DROP PROCEDURE IF EXISTS `sp_cursos_programados_por_profesor_en_rango`$$
+CREATE PROCEDURE `sp_cursos_programados_por_profesor_en_rango`(
+    IN p_id_profesor INT,
+    IN p_fecha_inicio DATE,
+    IN p_fecha_fin DATE,
+    IN p_id_curso_programado_excluir INT
+)
+BEGIN
+    SELECT
+        cp.id_curso_programado,
+        cp.fecha_inicio,
+        cp.fecha_fin,
+        cp.hora_inicio,
+        cp.hora_fin,
+        th.dias_semana
+    FROM cursos_programados cp
+    JOIN tipos_horario th ON cp.id_tipo_horario = th.id_tipo_horario
+    WHERE
+        cp.id_profesor = p_id_profesor
+        AND cp.fecha_inicio <= p_fecha_fin
+        AND cp.fecha_fin >= p_fecha_inicio
+        AND (p_id_curso_programado_excluir IS NULL OR cp.id_curso_programado != p_id_curso_programado_excluir);
+END$$
+
 DELIMITER ;

--- a/controllers/programar_horarios_controller.php
+++ b/controllers/programar_horarios_controller.php
@@ -49,6 +49,27 @@ try {
 
         case 'create':
             if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                // --- Validación de Cruce de Horarios ---
+                $id_profesor_a_validar = (int)$_POST['id_profesor'];
+                $dias_semana_nuevo = $programacionModel->getDiasSemanaByTipoHorarioId((int)$_POST['id_tipo_horario']);
+
+                if ($dias_semana_nuevo) {
+                    $dias_nuevos_arr = explode(',', $dias_semana_nuevo);
+                    $horarios_existentes = $programacionModel->getProfesorSchedulesInRange($id_profesor_a_validar, $_POST['fecha_inicio'], $_POST['fecha_fin']);
+
+                    foreach ($horarios_existentes as $horario) {
+                        if ($_POST['hora_inicio'] < $horario['hora_fin'] && $horario['hora_inicio'] < $_POST['hora_fin']) {
+                            $dias_existentes_arr = explode(',', $horario['dias_semana']);
+                            if (count(array_intersect($dias_nuevos_arr, $dias_existentes_arr)) > 0) {
+                                $_SESSION['feedback_message'] = "Error de validación: El profesor ya tiene un curso programado que se cruza con este horario (fecha, hora y día de la semana).";
+                                header('Location: index.php?view=programar_horarios&action=new');
+                                exit();
+                            }
+                        }
+                    }
+                }
+                // --- Fin de Validación ---
+
                 $datos = [
                     'id_curso' => $_POST['id_curso'],
                     'id_profesor' => $_POST['id_profesor'],
@@ -105,6 +126,28 @@ try {
                      header('Location: index.php?view=programar_horarios');
                      exit();
                 }
+
+                // --- Validación de Cruce de Horarios ---
+                $id_profesor_a_validar = (int)$_POST['id_profesor'];
+                $dias_semana_nuevo = $programacionModel->getDiasSemanaByTipoHorarioId((int)$_POST['id_tipo_horario']);
+
+                if ($dias_semana_nuevo) {
+                    $dias_nuevos_arr = explode(',', $dias_semana_nuevo);
+                    $horarios_existentes = $programacionModel->getProfesorSchedulesInRange($id_profesor_a_validar, $_POST['fecha_inicio'], $_POST['fecha_fin'], $id_programacion);
+
+                    foreach ($horarios_existentes as $horario) {
+                        if ($_POST['hora_inicio'] < $horario['hora_fin'] && $horario['hora_inicio'] < $_POST['hora_fin']) {
+                            $dias_existentes_arr = explode(',', $horario['dias_semana']);
+                            if (count(array_intersect($dias_nuevos_arr, $dias_existentes_arr)) > 0) {
+                                $_SESSION['feedback_message'] = "Error de validación: El profesor ya tiene un curso programado que se cruza con este horario (fecha, hora y día de la semana).";
+                                header('Location: index.php?view=programar_horarios&action=edit&id=' . $id_programacion);
+                                exit();
+                            }
+                        }
+                    }
+                }
+                // --- Fin de Validación ---
+
                 $datos = [
                     'id_curso_programado' => $id_programacion,
                     'id_curso' => $_POST['id_curso'],

--- a/models/ProgramacionModel.php
+++ b/models/ProgramacionModel.php
@@ -97,4 +97,15 @@ class ProgramacionModel {
         $this->db->callStoredProcedure('sp_cursos_programados_eliminar', [$id]);
         return $this->db->rowCount() > 0;
     }
+
+    public function getProfesorSchedulesInRange($profesorId, $startDate, $endDate, $excludeScheduleId = null) {
+        $this->db->callStoredProcedure('sp_cursos_programados_por_profesor_en_rango', [$profesorId, $startDate, $endDate, $excludeScheduleId]);
+        return $this->db->resultSet();
+    }
+
+    public function getDiasSemanaByTipoHorarioId($tipoHorarioId) {
+        $this->db->callStoredProcedure('sp_tipos_horario_obtener_por_id', [$tipoHorarioId]);
+        $result = $this->db->single();
+        return $result ? $result['dias_semana'] : null;
+    }
 }


### PR DESCRIPTION
Implemented a validation rule to prevent a professor from being scheduled for courses with overlapping times.

- Added a new stored procedure `sp_cursos_programados_por_profesor_en_rango` to get potentially conflicting schedules.
- Updated `models/ProgramacionModel.php` with new methods to support the validation.
- Added validation logic to the `create` and `update` actions in `controllers/programar_horarios_controller.php`. The logic checks for overlaps in date ranges, time ranges, and days of the week.
- If a conflict is found, the user is shown an error message and the schedule is not saved.