### PR TITLE
feat: Update location format on Course Monitor page

### DIFF
--- a/bd/stored_procedures_programacion.sql
+++ b/bd/stored_procedures_programacion.sql
@@ -118,4 +118,40 @@ BEGIN
         AND (p_id_curso_programado_excluir IS NULL OR cp.id_curso_programado != p_id_curso_programado_excluir);
 END$$
 
+
+DROP PROCEDURE IF EXISTS `sp_cursos_programados_buscar_disponibles`$$
+CREATE PROCEDURE `sp_cursos_programados_buscar_disponibles`(
+    IN p_profesor_id INT,
+    IN p_fecha_inicio DATE,
+    IN p_fecha_fin DATE
+)
+BEGIN
+    SELECT
+        cp.id_curso_programado,
+        c.nombre AS curso_nombre,
+        c.descripcion AS curso_descripcion,
+        CONCAT(p.nombres, ' ', p.apellidos) AS profesor_nombre,
+        CONCAT(a.nombre, ' - ', sa.descripcion, ' ', sa.numero_sub_area) AS ubicacion,
+        cp.fecha_inicio,
+        cp.fecha_fin,
+        cp.hora_inicio,
+        cp.hora_fin,
+        th.descripcion as tipo_horario_nombre,
+        cp.vacantes_disponibles
+    FROM cursos_programados cp
+    JOIN cursos c ON cp.id_curso = c.id_curso
+    JOIN profesores p ON cp.id_profesor = p.id_profesor
+    JOIN sub_areas sa ON cp.id_sub_area = sa.id_sub_area
+    JOIN areas a ON sa.id_area = a.id_area
+    JOIN tipos_horario th ON cp.id_tipo_horario = th.id_tipo_horario
+    WHERE
+        cp.vacantes_disponibles > 0
+        AND cp.estado = 'Programado'
+        AND (p_profesor_id IS NULL OR cp.id_profesor = p_profesor_id)
+        AND (p_fecha_inicio IS NULL OR cp.fecha_inicio >= p_fecha_inicio)
+        AND (p_fecha_fin IS NULL OR cp.fecha_fin <= p_fecha_fin)
+    ORDER BY cp.fecha_inicio;
+END$$
+
+
 DELIMITER ;


### PR DESCRIPTION
Updated the "Monitor de Cursos" page to display the location in the format "Area - Subarea numero_subarea", as requested by the user.

- Created a definition for the previously untracked stored procedure `sp_cursos_programados_buscar_disponibles` in the file `bd/stored_procedures_programacion.sql`.
- Modified this stored procedure to select and concatenate the location fields into the desired format.