### PR TITLE
fix: Correct SP and view for Course Monitor page

### DIFF
--- a/bd/update_monitor_sp.sql
+++ b/bd/update_monitor_sp.sql
@@ -1,0 +1,46 @@
+-- =================================================================
+-- Corrección para el Stored Procedure del Monitor de Cursos
+-- =================================================================
+
+USE `academia_cursos`;
+
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS `sp_cursos_programados_buscar_disponibles`$$
+CREATE PROCEDURE `sp_cursos_programados_buscar_disponibles`(
+    IN p_profesor_id INT,
+    IN p_fecha_inicio DATE,
+    IN p_fecha_fin DATE
+)
+BEGIN
+    SELECT
+        cp.id_curso_programado,
+        c.nombre AS nombre_curso,
+        c.descripcion AS curso_descripcion,
+        CONCAT(p.nombres, ' ', p.apellidos) AS nombre_profesor,
+        a.nombre AS area,
+        sa.descripcion AS sub_area,
+        sa.numero_sub_area,
+        cp.fecha_inicio,
+        cp.fecha_fin,
+        cp.hora_inicio,
+        cp.hora_fin,
+        th.descripcion as horario_dias,
+        cp.vacantes_disponibles,
+        (SELECT lp.precio FROM lista_precios lp WHERE lp.id_curso = c.id_curso AND lp.vigencia_inicio <= CURDATE() AND lp.vigencia_fin >= CURDATE() ORDER BY lp.id_tipo_precio LIMIT 1) AS precio_actual
+    FROM cursos_programados cp
+    JOIN cursos c ON cp.id_curso = c.id_curso
+    JOIN profesores p ON cp.id_profesor = p.id_profesor
+    JOIN sub_areas sa ON cp.id_sub_area = sa.id_sub_area
+    JOIN areas a ON sa.id_area = a.id_area
+    JOIN tipos_horario th ON cp.id_tipo_horario = th.id_tipo_horario
+    WHERE
+        cp.vacantes_disponibles > 0
+        AND cp.estado = 'Programado'
+        AND (p_profesor_id IS NULL OR cp.id_profesor = p_profesor_id)
+        AND (p_fecha_inicio IS NULL OR cp.fecha_inicio >= p_fecha_inicio)
+        AND (p_fecha_fin IS NULL OR cp.fecha_fin <= p_fecha_fin)
+    ORDER BY cp.fecha_inicio;
+END$$
+
+DELIMITER ;

--- a/views/monitor_view.php
+++ b/views/monitor_view.php
@@ -19,7 +19,7 @@
                 <p><strong>Profesor:</strong> <?php echo htmlspecialchars($curso['nombre_profesor']); ?></p>
                 <p><strong>Periodo:</strong> <?php echo date('d/m/Y', strtotime($curso['fecha_inicio'])); ?> - <?php echo date('d/m/Y', strtotime($curso['fecha_fin'])); ?></p>
                 <p><strong>Horario:</strong> <?php echo htmlspecialchars($curso['horario_dias']); ?> (<?php echo date('H:i', strtotime($curso['hora_inicio'])); ?> - <?php echo date('H:i', strtotime($curso['hora_fin'])); ?>)</p>
-                <p><strong>Ubicación:</strong> <?php echo htmlspecialchars($curso['area']); ?> - <?php echo htmlspecialchars($curso['sub_area']); ?></p>
+                <p><strong>Ubicación:</strong> <?php echo htmlspecialchars($curso['area'] . ' - ' . $curso['sub_area'] . ' ' . $curso['numero_sub_area']); ?></p>
                 <p><strong>Vacantes:</strong> <?php echo htmlspecialchars($curso['vacantes_disponibles']); ?></p>
                 <p><strong>Precio:</strong> S/ <?php echo number_format($curso['precio_actual'], 2); ?></p>
             </div>


### PR DESCRIPTION
Fixed several "Notice: Undefined index" errors on the "Monitor de Cursos" page that were caused by a mismatch between the view and the `sp_cursos_programados_buscar_disponibles` stored procedure.

- Created a new file `bd/update_monitor_sp.sql` with the corrected stored procedure definition to ensure it is tracked in the repository.
- The stored procedure now returns all the columns with the exact aliases that the view expects (`nombre_curso`, `nombre_profesor`, etc.).
- Added the `precio_actual` column to the query via a subquery on `lista_precios`.
- Updated the view to display the `Ubicación` in the user-requested format of "Area - Subarea numero_subarea".