### PR TITLE
feat: Add pagination and i18n to Professor Attendance form

### DIFF
--- a/bd/stored_procedures_asistencia.sql
+++ b/bd/stored_procedures_asistencia.sql
@@ -84,9 +84,13 @@ END$$
 
 
 -- `sp_asistencia_profesor_obtener_clases`
--- Gets the list of individual class dates for a scheduled course.
+-- Gets the list of individual class dates for a scheduled course (paginated).
 DROP PROCEDURE IF EXISTS `sp_asistencia_profesor_obtener_clases`$$
-CREATE PROCEDURE `sp_asistencia_profesor_obtener_clases`(IN p_id_curso_programado INT)
+CREATE PROCEDURE `sp_asistencia_profesor_obtener_clases`(
+    IN p_id_curso_programado INT,
+    IN p_limit INT,
+    IN p_offset INT
+)
 BEGIN
     SELECT
         id_asistencia_profesor,
@@ -95,7 +99,19 @@ BEGIN
         observaciones
     FROM asistencia_profesor
     WHERE id_curso_programado = p_id_curso_programado
-    ORDER BY fecha_clase ASC;
+    ORDER BY fecha_clase ASC
+    LIMIT p_limit OFFSET p_offset;
+END$$
+
+
+-- `sp_asistencia_profesor_contar_clases`
+-- Counts the total number of class dates for a scheduled course.
+DROP PROCEDURE IF EXISTS `sp_asistencia_profesor_contar_clases`$$
+CREATE PROCEDURE `sp_asistencia_profesor_contar_clases`(IN p_id_curso_programado INT)
+BEGIN
+    SELECT COUNT(id_asistencia_profesor) as total
+    FROM asistencia_profesor
+    WHERE id_curso_programado = p_id_curso_programado;
 END$$
 
 

--- a/controllers/asistencia_profesores_controller.php
+++ b/controllers/asistencia_profesores_controller.php
@@ -32,8 +32,16 @@ try {
     switch ($action) {
         case 'marcar':
             if ($id_curso_programado > 0) {
+                // Lógica de Paginación
+                $limit = 10;
+                $pagina_actual = (int)($_GET['page'] ?? 1);
+                $offset = ($pagina_actual - 1) * $limit;
+
+                $total_clases = $asistenciaModel->contarClases($id_curso_programado);
+                $total_paginas = ceil($total_clases / $limit);
+
                 $detalle_curso = $asistenciaModel->obtenerDetalleCurso($id_curso_programado);
-                $clases = $asistenciaModel->obtenerClases($id_curso_programado);
+                $clases = $asistenciaModel->obtenerClases($id_curso_programado, $limit, $offset);
 
                 if (!$detalle_curso) {
                     $_SESSION['feedback_message'] = "Error: El curso programado no fue encontrado.";

--- a/models/AsistenciaProfesorModel.php
+++ b/models/AsistenciaProfesorModel.php
@@ -21,9 +21,15 @@ class AsistenciaProfesorModel {
         return $this->db->single();
     }
 
-    public function obtenerClases($id_curso_programado) {
-        $this->db->callStoredProcedure('sp_asistencia_profesor_obtener_clases', [$id_curso_programado]);
+    public function obtenerClases($id_curso_programado, $limit, $offset) {
+        $this->db->callStoredProcedure('sp_asistencia_profesor_obtener_clases', [$id_curso_programado, $limit, $offset]);
         return $this->db->resultSet();
+    }
+
+    public function contarClases($id_curso_programado) {
+        $this->db->callStoredProcedure('sp_asistencia_profesor_contar_clases', [$id_curso_programado]);
+        $result = $this->db->single();
+        return $result ? (int)$result['total'] : 0;
     }
 
     public function actualizarAsistencia($id_asistencia, $estado, $observaciones) {

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -329,6 +329,14 @@ footer {
     text-align: right;
 }
 
+.pagination-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 2rem;
+    gap: 0.5rem;
+}
+
 /* Autocomplete / Search Results */
 .search-results {
     position: relative;

--- a/views/asistencia_profesor/form.php
+++ b/views/asistencia_profesor/form.php
@@ -1,4 +1,15 @@
-<?php require_once 'views/partials/header.php'; ?>
+<?php
+require_once 'views/partials/header.php';
+$dias_es = [
+    'Monday'    => 'Lunes',
+    'Tuesday'   => 'Martes',
+    'Wednesday' => 'Miércoles',
+    'Thursday'  => 'Jueves',
+    'Friday'    => 'Viernes',
+    'Saturday'  => 'Sábado',
+    'Sunday'    => 'Domingo'
+];
+?>
 
 <div class="page-header">
     <h1>Marcar Asistencia de Profesor</h1>
@@ -34,7 +45,13 @@
             <?php else: ?>
                 <?php foreach ($clases as $clase): ?>
                     <tr>
-                        <td><?php echo date('d/m/Y (l)', strtotime($clase['fecha_clase'])); ?></td>
+                        <td>
+                            <?php
+                                $dia_ingles = date('l', strtotime($clase['fecha_clase']));
+                                $dia_espanol = $dias_es[$dia_ingles] ?? $dia_ingles;
+                                echo date('d/m/Y', strtotime($clase['fecha_clase'])) . ' (' . $dia_espanol . ')';
+                            ?>
+                        </td>
                         <td>
                             <input type="hidden" name="asistencia[<?php echo $clase['id_asistencia_profesor']; ?>][id]" value="<?php echo $clase['id_asistencia_profesor']; ?>">
                             <select name="asistencia[<?php echo $clase['id_asistencia_profesor']; ?>][estado]" required>
@@ -52,6 +69,23 @@
             <?php endif; ?>
         </tbody>
     </table>
+
+    <!-- Paginación -->
+    <?php if ($total_paginas > 1): ?>
+        <div class="pagination-container">
+            <?php if ($pagina_actual > 1): ?>
+                <a href="index.php?view=asistencia_profesores&action=marcar&id=<?php echo $id_curso_programado; ?>&page=<?php echo $pagina_actual - 1; ?>" class="btn">&laquo; Anterior</a>
+            <?php endif; ?>
+
+            <?php for ($i = 1; $i <= $total_paginas; $i++): ?>
+                <a href="index.php?view=asistencia_profesores&action=marcar&id=<?php echo $id_curso_programado; ?>&page=<?php echo $i; ?>" class="btn <?php echo ($i == $pagina_actual) ? 'btn-primary' : 'btn-secondary'; ?>"><?php echo $i; ?></a>
+            <?php endfor; ?>
+
+            <?php if ($pagina_actual < $total_paginas): ?>
+                <a href="index.php?view=asistencia_profesores&action=marcar&id=<?php echo $id_curso_programado; ?>&page=<?php echo $pagina_actual + 1; ?>" class="btn">Siguiente &raquo;</a>
+            <?php endif; ?>
+        </div>
+    <?php endif; ?>
 
     <div class="form-actions">
         <a href="index.php?view=asistencia_profesores" class="btn btn-secondary">Cancelar</a>


### PR DESCRIPTION
Implemented two enhancements for the "Marcar Asistencia de Profesor" page as per user request.

1.  **Pagination:**
    - The list of class dates is now paginated, showing 10 records per page.
    - Updated the `sp_asistencia_profesor_obtener_clases` stored procedure to support LIMIT/OFFSET.
    - Added a new `sp_asistencia_profesor_contar_clases` stored procedure to get the total record count.
    - Updated the model and controller to handle pagination logic.
    - Added pagination controls to the view.

2.  **Internationalization (i18n):**
    - The day of the week names in the class list are now displayed in Spanish.
    - Added a PHP translation array to the view to convert English day names from the `date()` function to Spanish.