### PR TITLE
fix: Correct day-of-week calculation for schedule generation

### DIFF
--- a/bd/stored_procedures_asistencia.sql
+++ b/bd/stored_procedures_asistencia.sql
@@ -29,10 +29,10 @@ BEGIN
 
     -- Bucle para generar registros de asistencia
     WHILE v_fecha_actual <= v_fecha_fin DO
-        -- DAYOFWEEK devuelve 1 para Domingo, 2 para Lunes, etc.
+        -- WEEKDAY() devuelve 0 para Lunes, 1 para Martes, etc. Se suma 1 para alinear con el formato guardado (Lunes=1, etc.)
         -- Se inserta si el día de la semana está en la cadena de días permitidos
         -- Se usa COLLATE para forzar la codificación correcta y evitar errores
-        IF FIND_IN_SET(DAYOFWEEK(v_fecha_actual), v_dias_semana COLLATE utf8mb4_unicode_ci) THEN
+        IF FIND_IN_SET(WEEKDAY(v_fecha_actual) + 1, v_dias_semana COLLATE utf8mb4_unicode_ci) THEN
             INSERT INTO asistencia_profesor (id_curso_programado, id_profesor, fecha_clase, estado)
             VALUES (p_id_curso_programado, v_id_profesor, v_fecha_actual, 'Programado');
         END IF;


### PR DESCRIPTION
Fixed a critical bug where the automatic generation of class dates for professor attendance was creating entries for the wrong days of the week.

- The error was in the `sp_asistencia_profesor_generar_cronograma` stored procedure.
- Replaced the `DAYOFWEEK()` function (where Sunday = 1) with `WEEKDAY() + 1` (where Monday = 1).
- This aligns the day calculation with the application's convention for storing days in the `tipos_horario` table and ensures correct dates are generated.