### PR TITLE
feat: Add location to course card in enrollment search

### DIFF
--- a/public/assets/js/matricula_form.js
+++ b/public/assets/js/matricula_form.js
@@ -117,6 +117,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
                         card.innerHTML = `
                             <h4>${curso.nombre_curso}</h4>
+                            <p><small><strong>Ubicación:</strong> ${curso.area} - ${curso.sub_area} ${curso.numero_sub_area}</small></p>
                             <p><strong>Profesor:</strong> ${curso.nombre_profesor}</p>
                             <p><strong>Periodo:</strong> ${formatDate(curso.fecha_inicio)} - ${formatDate(curso.fecha_fin)}</p>
                             <p><strong>Horario:</strong> ${curso.horario_dias}</p>


### PR DESCRIPTION
Updated the dynamically generated course cards on the "Nueva Matrícula" page to include the location.

- The "Ubicación" is now displayed after the course name.
- The format is "Area - Subarea numero_subarea".
- The JavaScript file `public/assets/js/matricula_form.js` was updated to add the new field to the card's HTML.