### PR TITLE
refactor: Refine enrollment grid layout

### DIFF
--- a/public/assets/js/matricula_form.js
+++ b/public/assets/js/matricula_form.js
@@ -174,9 +174,7 @@ document.addEventListener('DOMContentLoaded', function() {
             <td>${curso.nombre}<input type="hidden" name="cursos[${curso.id}][id_curso]" value="${curso.id}"></td>
             <td>${curso.ubicacion}</td>
             <td>${curso.profesor}</td>
-            <td>${curso.horario}</td>
-            <td>${curso.horas}</td>
-            <td>${curso.precio.toFixed(2)}</td>
+            <td>${curso.horario}<br><small>${curso.horas}</small></td>
             <td><input type="number" class="recalc-trigger" name="cursos[${curso.id}][precio_pactado]" value="${curso.precio.toFixed(2)}" step="0.01"></td>
             <td><input type="number" class="recalc-trigger" name="cursos[${curso.id}][descuento]" value="0.00" step="0.01"></td>
             <td class="precio-final">${precioFinal.toFixed(2)}</td>

--- a/views/matricula_nueva_view.php
+++ b/views/matricula_nueva_view.php
@@ -56,9 +56,7 @@
                             <th>Curso</th>
                             <th>Ubicación</th>
                             <th>Profesor</th>
-                            <th>Horario</th>
-                            <th>Horas</th>
-                            <th>Precio Orig.</th>
+                            <th>Horario y Horas</th>
                             <th>Precio Pactado</th>
                             <th>Descuento</th>
                             <th>Precio Final</th>
@@ -70,7 +68,7 @@
                     </tbody>
                     <tfoot>
                         <tr>
-                            <td colspan="9" class="total-row">TOTAL:</td>
+                            <td colspan="7" class="total-row">TOTAL:</td>
                             <td id="total-matricula" class="total-row">S/ 0.00</td>
                             <td></td>
                         </tr>


### PR DESCRIPTION
Made final UI adjustments to the selected courses grid on the "Nueva Matrícula" page as per user request.

- Combined the "Horario" (Days) and "Horas" (Times) columns into a single column for a cleaner layout.
- Hid the "Precio Orig." (Original Price) column as it was redundant.
- Updated the table headers in the view and the row generation logic in the JavaScript file to reflect these changes.