### PR TITLE
refactor: Hide date fields in enrollment payment section

### DIFF
--- a/views/matricula_nueva_view.php
+++ b/views/matricula_nueva_view.php
@@ -81,14 +81,9 @@
         <div class="section">
             <h2>3. Datos del Pago</h2>
             <div class="form-grid">
-                <div class="form-group">
-                    <label for="fecha_inicio_matricula">Fecha Inicio Matrícula:</label>
-                    <input type="date" id="fecha_inicio_matricula" name="fecha_inicio_matricula" readonly>
-                </div>
-                <div class="form-group">
-                    <label for="fecha_fin_matricula">Fecha Fin Matrícula:</label>
-                    <input type="date" id="fecha_fin_matricula" name="fecha_fin_matricula" readonly>
-                </div>
+                <!-- Las fechas se copian desde los filtros y se envían de forma oculta -->
+                <input type="hidden" id="fecha_inicio_matricula" name="fecha_inicio_matricula">
+                <input type="hidden" id="fecha_fin_matricula" name="fecha_fin_matricula">
                 <div class="form-group">
                     <label for="id_forma_pago">Forma de Pago:</label>
                     <select id="id_forma_pago" name="id_forma_pago" required>


### PR DESCRIPTION
Updated the "Nueva Matrícula" page to simplify the UI in the "Datos del Pago" section.

- The "Fecha Inicio Matrícula" and "Fecha Fin Matrícula" input fields have been changed from type `date` to `hidden`.
- This removes them from the user's view, as they are populated automatically from the search filters, but preserves their functionality for the form submission.