### PR TITLE
fix: Correct table name for enrollments

### DIFF
--- a/bd/stored_procedures_asistencia_cliente.sql
+++ b/bd/stored_procedures_asistencia_cliente.sql
@@ -31,7 +31,7 @@ BEGIN
         CONCAT(TIME_FORMAT(cp.hora_inicio, '%h:%i %p'), ' - ', TIME_FORMAT(cp.hora_fin, '%h:%i %p')) AS horas,
         CONCAT(a.nombre, ' - ', sa.descripcion, ' ', sa.numero_sub_area) AS ubicacion,
         mc.estado
-    FROM matriculas_cabecera mc
+    FROM matriculas mc
     JOIN matriculas_detalle md ON mc.id_matricula = md.id_matricula
     JOIN clientes cli ON md.id_cliente_asistencia = cli.id_cliente
     JOIN cursos_programados cp ON md.id_curso_programado = cp.id_curso_programado

--- a/bd/update_v1.14.sql
+++ b/bd/update_v1.14.sql
@@ -9,7 +9,7 @@ BEGIN
     FROM
         matriculas_detalle md
     JOIN
-        matriculas_cabecera mc ON md.id_matricula = mc.id_matricula
+        matriculas mc ON md.id_matricula = mc.id_matricula
     WHERE
         md.id_curso_programado = p_id_curso_programado
         AND mc.estado = 1; -- Contar solo matrículas activas

--- a/bd/update_v1.15.sql
+++ b/bd/update_v1.15.sql
@@ -20,7 +20,7 @@ BEGIN
     WHERE id_matricula = p_id_matricula;
 
     -- 3. Delete the header record.
-    DELETE FROM matriculas_cabecera
+    DELETE FROM matriculas
     WHERE id_matricula = p_id_matricula;
 
     COMMIT;

--- a/bd/update_v1.16.sql
+++ b/bd/update_v1.16.sql
@@ -17,7 +17,7 @@ BEGIN
         fp.nombre AS forma_pago,
         CASE mc.estado WHEN 1 THEN 'Activa' WHEN 0 THEN 'Anulada' END AS estado
     FROM
-        matriculas_cabecera mc
+        matriculas mc
     JOIN
         clientes c ON mc.id_cliente = c.id_cliente
     JOIN

--- a/bd/update_v1.17.sql
+++ b/bd/update_v1.17.sql
@@ -40,7 +40,7 @@ BEGIN
     SET v_monto_final = v_monto_total - v_descuento_total;
 
     -- Actualizar la cabecera de la matrícula.
-    UPDATE matriculas_cabecera
+    UPDATE matriculas
     SET
         monto_total = v_monto_total,
         descuento_total = v_descuento_total,


### PR DESCRIPTION
This commit fixes a critical bug that caused a 'Table not found' error when creating an enrollment.

The root cause was the incorrect use of `matriculas_cabecera` instead of the correct table name `matriculas` in several new stored procedures. This has been corrected in all relevant SQL files.