### PR TITLE
fix: Corregir el SP de registro de cabecera de matrícula

### DIFF
--- a/bd/update_v1.19.sql
+++ b/bd/update_v1.19.sql
@@ -1,0 +1,34 @@
+-- =================================================================
+-- Script de Actualización de la Base de Datos - Versión 1.19
+-- Corrige una posible versión desactualizada del SP sp_matricula_registrar_cabecera.
+-- =================================================================
+
+USE `academia_cursos`;
+
+DELIMITER $$
+
+-- -----------------------------------------------------
+-- `sp_matricula_registrar_cabecera`
+-- Se asegura que la versión de este SP sea la correcta, utilizando
+-- la tabla `matriculas` en lugar de una inexistente `matriculas_cabecera`.
+-- -----------------------------------------------------
+DROP PROCEDURE IF EXISTS `sp_matricula_registrar_cabecera`$$
+CREATE PROCEDURE `sp_matricula_registrar_cabecera`(
+    IN p_id_cliente INT,
+    IN p_id_usuario_registro INT,
+    IN p_id_forma_pago INT,
+    IN p_fecha_inicio_clases DATE,
+    IN p_fecha_fin_clases DATE,
+    IN p_monto_total DECIMAL(10,2),
+    IN p_descuento_total DECIMAL(10,2),
+    IN p_monto_final DECIMAL(10,2),
+    IN p_observaciones TEXT
+)
+BEGIN
+    INSERT INTO matriculas (id_cliente, id_usuario_registro, id_forma_pago, fecha_inicio_clases, fecha_fin_clases, monto_total, descuento_total, monto_final, observaciones)
+    VALUES (p_id_cliente, p_id_usuario_registro, p_id_forma_pago, p_fecha_inicio_clases, p_fecha_fin_clases, p_monto_total, p_descuento_total, p_monto_final, p_observaciones);
+
+    SELECT LAST_INSERT_ID() as id_matricula;
+END$$
+
+DELIMITER ;


### PR DESCRIPTION
Se ha detectado un error en el entorno del usuario que indica que la tabla `matriculas_cabecera` no existe. Este error se produce al registrar una nueva matrícula.

Aunque los archivos del repositorio parecen correctos, este cambio introduce un nuevo script de actualización (`update_v1.19.sql`) que redefine explícitamente el procedimiento almacenado `sp_matricula_registrar_cabecera`.

Este script asegura que el procedimiento utilice la tabla correcta `matriculas` y sobrescriba cualquier versión desactualizada o incorrecta que pueda existir en el entorno de la base de datos del usuario, solucionando así el error reportado.