### PR TITLE
hotfix: Reemplazar SP con SQL directo en registro de matrícula

### DIFF
--- a/models/MatriculaModel.php
+++ b/models/MatriculaModel.php
@@ -28,23 +28,25 @@ class MatriculaModel {
         $this->db->beginTransaction();
 
         try {
-            // 1. Registrar cabecera
-            $params_cabecera = [
-                $datos['id_cliente'],
-                $_SESSION['user_id'], // El usuario que registra
-                $datos['id_forma_pago'],
-                $datos['fecha_inicio_matricula'],
-                $datos['fecha_fin_matricula'],
-                $datos['monto_total'],
-                $datos['descuento_total'],
-                $datos['monto_final'],
-                $datos['observaciones']
-            ];
-            $stmt_cabecera = $this->db->callStoredProcedure('sp_matricula_registrar_cabecera', $params_cabecera);
-            $result_cabecera = $this->db->single();
-            $id_matricula = $result_cabecera['id_matricula'] ?? 0;
+            // 1. Registrar cabecera (usando SQL directo para evitar SP con error)
+            $sql = "INSERT INTO matriculas (id_cliente, id_usuario_registro, id_forma_pago, fecha_inicio_clases, fecha_fin_clases, monto_total, descuento_total, monto_final, observaciones, estado)
+                    VALUES (:id_cliente, :id_usuario_registro, :id_forma_pago, :fecha_inicio_clases, :fecha_fin_clases, :monto_total, :descuento_total, :monto_final, :observaciones, 'Activa')";
 
-            if ($id_matricula == 0) {
+            $this->db->query($sql);
+            $this->db->bind(':id_cliente', $datos['id_cliente']);
+            $this->db->bind(':id_usuario_registro', $_SESSION['user_id']);
+            $this->db->bind(':id_forma_pago', $datos['id_forma_pago']);
+            $this->db->bind(':fecha_inicio_clases', $datos['fecha_inicio_matricula']);
+            $this->db->bind(':fecha_fin_clases', $datos['fecha_fin_matricula']);
+            $this->db->bind(':monto_total', $datos['monto_total']);
+            $this->db->bind(':descuento_total', $datos['descuento_total']);
+            $this->db->bind(':monto_final', $datos['monto_final']);
+            $this->db->bind(':observaciones', $datos['observaciones']);
+
+            $this->db->execute();
+            $id_matricula = $this->db->lastInsertId();
+
+            if (!$id_matricula) {
                 throw new Exception("No se pudo crear la cabecera de la matrícula.");
             }
 


### PR DESCRIPTION
Para solucionar un error persistente de base de datos (`Table 'matriculas_cabecera' doesn't exist`) que no se pudo resolver actualizando los scripts de SP, este cambio modifica el método `registrarMatricula` en `MatriculaModel.php`.

Se ha reemplazado la llamada al procedimiento almacenado `sp_matricula_registrar_cabecera` por una consulta SQL `INSERT` directa y parametrizada.

Este enfoque asegura que la consulta correcta se ejecute directamente desde la aplicación, evitando la dependencia de un procedimiento almacenado potencialmente corrupto o desactualizado en el entorno de base de datos del usuario. Esto proporciona una solución definitiva al problema reportado.