### PR TITLE
hotfix: Restaurar método eliminado en MatriculaModel

### DIFF
--- a/models/MatriculaModel.php
+++ b/models/MatriculaModel.php
@@ -112,6 +112,16 @@ class MatriculaModel {
     }
 
     /**
+     * Obtiene todos los horarios activos para un cliente específico.
+     * @param int $id_cliente
+     * @return array Lista de horarios activos.
+     */
+    public function obtenerHorariosActivosPorCliente($id_cliente) {
+        $this->db->callStoredProcedure('sp_cliente_horarios_activos', [$id_cliente]);
+        return $this->db->resultSet();
+    }
+
+    /**
      * Elimina permanentemente una matrícula y todos sus registros asociados.
      * @param int $id_matricula
      * @return bool


### PR DESCRIPTION
Este commit corrige un error fatal (`Call to undefined method MatriculaModel::obtenerHorariosActivosPorCliente()`) que fue introducido accidentalmente en un commit anterior.

Al restaurar el archivo `models/MatriculaModel.php` para solucionar un problema de base de datos, el método `obtenerHorariosActivosPorCliente` fue eliminado. Este método es esencial para la validación de cruce de horarios en `matriculas_controller.php`.

Este parche vuelve a añadir el método `obtenerHorariosActivosPorCliente` a la clase `MatriculaModel`, resolviendo el error fatal y restaurando la funcionalidad completa de validación de matrículas.