### PR TITLE
feat: Añadir colores a los estados de matrícula

### DIFF
--- a/views/matriculas_view.php
+++ b/views/matriculas_view.php
@@ -112,4 +112,24 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 
+<style>
+.badge {
+    padding: 5px 10px;
+    border-radius: 12px;
+    color: #fff;
+    font-weight: bold;
+    font-size: 0.9em;
+    text-shadow: 1px 1px 1px rgba(0,0,0,0.1);
+}
+.status-activa {
+    background-color: #28a745; /* Verde */
+}
+.status-anulada {
+    background-color: #dc3545; /* Rojo */
+}
+.status-completada {
+    background-color: #007bff; /* Azul */
+}
+</style>
+
 <?php require_once 'views/partials/footer.php'; ?>


### PR DESCRIPTION
Se ha añadido un bloque de CSS a la vista `matriculas_view.php` para colorear los badges de estado en la grilla de matrículas.

Esto mejora la usabilidad de la interfaz, permitiendo a los usuarios identificar rápidamente el estado de una matrícula de un vistazo.

Los colores aplicados son:
- Verde para 'Activa'
- Rojo para 'Anulada'
- Azul para 'Completada'