### PR TITLE
fix: Crear archivo de helpers faltante y añadir función

### DIFF
--- a/utils/helpers.php
+++ b/utils/helpers.php
@@ -1,0 +1,27 @@
+<?php
+
+// =================================================================
+// Archivo de Funciones de Ayuda (Helpers)
+// =================================================================
+
+if (!function_exists('get_day_name_es')) {
+    /**
+     * Devuelve el nombre en español para un día de la semana numérico.
+     *
+     * @param int $day_of_week_numeric Un número del 1 (Lunes) al 7 (Domingo).
+     * @return string El nombre del día en español.
+     */
+    function get_day_name_es($day_of_week_numeric) {
+        $dias = [
+            1 => 'Lunes',
+            2 => 'Martes',
+            3 => 'Miércoles',
+            4 => 'Jueves',
+            5 => 'Viernes',
+            6 => 'Sábado',
+            7 => 'Domingo'
+        ];
+
+        return $dias[$day_of_week_numeric] ?? 'Día no válido';
+    }
+}


### PR DESCRIPTION
Se ha solucionado un error fatal (`failed to open stream`) en el controlador de asistencia de clientes (`asistencia_clientes_controller.php`).

El error era causado porque el controlador intentaba incluir un archivo (`utils/helpers.php`) que no existía en el repositorio. Este archivo contenía una función necesaria, `get_day_name_es()`, para traducir los nombres de los días de la semana al español.

Este commit crea el archivo `utils/helpers.php` y define la función `get_day_name_es()` dentro de él, resolviendo así el error fatal y permitiendo que la página de asistencia de clientes se cargue correctamente.