### PR TITLE
fix: Añadir método faltante Session::isTeacher()

### DIFF
--- a/core/Session.php
+++ b/core/Session.php
@@ -66,4 +66,15 @@ class Session {
         // Asumimos que el rol de Administrador tiene id = 1
         return (isset($_SESSION['user_role']) && $_SESSION['user_role'] == 1);
     }
+
+    /**
+     * Verifica si el usuario actual tiene el rol de Profesor.
+     * @return bool
+     */
+    public static function isTeacher() {
+        // NOTA: El rol de "Profesor" no está definido en el esquema de BD inicial.
+        // Se asume un ID hipotético de 3 para este rol.
+        // Si se define un rol de profesor, se debe actualizar este ID.
+        return (isset($_SESSION['user_role']) && $_SESSION['user_role'] == 3);
+    }
 }


### PR DESCRIPTION
Se ha solucionado un error fatal (`Call to undefined method Session::isTeacher()`) que ocurría en el controlador `asistencia_clientes_controller.php`.

El error era causado por una llamada a un método estático `isTeacher()` en la clase `Session` que no estaba definido. Este método es parte de una comprobación de seguridad para restringir el acceso a la página.

Este commit añade el método `isTeacher()` a la clase `Session` en `core/Session.php`. Dado que no existe un rol de "Profesor" definido en la base de datos, el método comprueba un ID de rol hipotético (3) para evitar alterar la lógica de seguridad existente y simplemente resolver el error fatal. Se ha añadido un comentario para indicar que este ID debe ser actualizado si se crea formalmente el rol.