### PR TITLE
fix: Corregir lógica de transacción anidada en eliminación de detalle

### DIFF
--- a/models/MatriculaModel.php
+++ b/models/MatriculaModel.php
@@ -249,7 +249,7 @@ class MatriculaModel {
      * @return bool
      */
     public function eliminarDetalle($id_matricula_detalle, $id_matricula) {
-        $this->db->beginTransaction();
+        // La transacción es manejada por el método que llama (ej. actualizarMatricula)
         try {
             // 1. Eliminar el detalle y su asistencia
             $this->db->callStoredProcedure('sp_matricula_detalle_eliminar', [$id_matricula_detalle]);
@@ -257,10 +257,9 @@ class MatriculaModel {
             // 2. Recalcular los totales de la cabecera
             $this->db->callStoredProcedure('sp_matricula_cabecera_recalcular', [$id_matricula]);
 
-            $this->db->commit();
             return true;
         } catch (Exception $e) {
-            $this->db->rollBack();
+            // Propagar la excepción para que la transacción principal haga rollback.
             throw new Exception("Error al eliminar el detalle de la matrícula: " . $e->getMessage());
         }
     }


### PR DESCRIPTION
Se ha solucionado un error que impedía que se guardara la eliminación de un curso (detalle) al editar una matrícula.

El problema era causado por una transacción de base de datos anidada. El método `eliminarDetalle` iniciaba su propia transacción, la cual interfería con la transacción principal del método `actualizarMatricula`.

La corrección consiste en eliminar el manejo de la transacción (`beginTransaction`, `commit`, `rollBack`) del método `eliminarDetalle`. Ahora, este método se ejecuta dentro del contexto de la transacción de su método llamador (`actualizarMatricula`), asegurando que la eliminación del detalle se confirme junto con el resto de las actualizaciones de la matrícula.