### PR TITLE
hotfix: Restaurar todos los métodos faltantes en MatriculaModel

### DIFF
--- a/models/MatriculaModel.php
+++ b/models/MatriculaModel.php
@@ -187,6 +187,21 @@ class MatriculaModel {
     }
 
     /**
+     * Reverte la anulación de una matrícula, volviéndola al estado 'Activa'.
+     * @param int $id_matricula
+     * @return bool
+     */
+    public function revertirAnulacion($id_matricula) {
+        try {
+            $this->db->callStoredProcedure('sp_matricula_revertir_anulacion', [$id_matricula]);
+            return true;
+        } catch (Exception $e) {
+            // El SP lanzará un error si no hay vacantes o si la matrícula no está anulada.
+            throw new Exception("Error al revertir la anulación: " . $e->getMessage());
+        }
+    }
+
+    /**
      * Cuenta el número de alumnos inscritos en un curso programado específico.
      * @param int $id_curso_programado
      * @return int El número de alumnos inscritos.


### PR DESCRIPTION
Este commit final corrige una serie de errores fatales (`Call to undefined method`) que fueron causados por una restauración incompleta del archivo `models/MatriculaModel.php` en un commit anterior.

Al restaurar el archivo, se eliminaron accidentalmente varios métodos nuevos que se habían añadido durante la sesión. Este parche restaura el último método que faltaba: `revertirAnulacion`.

Con este cambio, la clase `MatriculaModel` vuelve a tener todos los métodos necesarios para las funcionalidades de crear, editar y revertir matrículas, solucionando de forma definitiva los errores reportados.