### PR TITLE
fix: Corregir estado de asistencia y mejorar UI

### DIFF
--- a/bd/update_v1.27_fix_attendance_status.sql
+++ b/bd/update_v1.27_fix_attendance_status.sql
@@ -1,0 +1,124 @@
+-- =================================================================
+-- Script de Actualización de la Base de Datos - Versión 1.27
+-- Corrige el estado de la asistencia para anulaciones y reversiones.
+-- =================================================================
+
+USE `academia_cursos`;
+
+-- 1. Añadir el estado 'Cancelado' al ENUM de la tabla de asistencia de clientes.
+-- Esto es necesario porque el SP de anulación lo usa, pero no estaba en la definición de la tabla.
+ALTER TABLE `asistencia_cliente`
+MODIFY COLUMN `estado` ENUM('Programado', 'Asistió', 'Faltó', 'Justificado', 'Postergado', 'Cancelado') NOT NULL DEFAULT 'Programado';
+
+
+DELIMITER $$
+
+-- 2. Redefinir el SP de anulación para asegurar consistencia.
+-- El SP original ya era funcional, pero se redefine aquí para consolidar el arreglo.
+DROP PROCEDURE IF EXISTS `sp_matricula_anular`$$
+CREATE PROCEDURE `sp_matricula_anular`(IN p_id_matricula INT, IN p_observaciones TEXT)
+BEGIN
+    DECLARE v_estado_actual VARCHAR(20);
+    START TRANSACTION;
+    SELECT estado INTO v_estado_actual FROM matriculas WHERE id_matricula = p_id_matricula;
+    IF v_estado_actual = 'Activa' THEN
+        UPDATE matriculas SET estado = 'Anulada', observaciones = CONCAT(IFNULL(observaciones, ''), '\nANULACIÓN: ', p_observaciones) WHERE id_matricula = p_id_matricula;
+
+        -- Liberar vacantes
+        UPDATE cursos_programados cp
+        JOIN matriculas_detalle md ON cp.id_curso_programado = md.id_curso_programado
+        SET cp.vacantes_disponibles = cp.vacantes_disponibles + 1
+        WHERE md.id_matricula = p_id_matricula;
+
+        -- Marcar asistencia como cancelada
+        UPDATE asistencia_cliente ac
+        JOIN matriculas_detalle md ON ac.id_matricula_detalle = md.id_matricula_detalle
+        SET ac.estado = 'Cancelado'
+        WHERE md.id_matricula = p_id_matricula;
+
+        COMMIT;
+    ELSE
+        ROLLBACK;
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'La matrícula no se puede anular porque no está activa.';
+    END IF;
+END$$
+
+
+-- 3. Redefinir el SP de reversión para asegurar que funciona con el nuevo ENUM.
+-- El SP original ya era funcional, pero se redefine para consolidar.
+DROP PROCEDURE IF EXISTS `sp_matricula_revertir_anulacion`$$
+CREATE PROCEDURE `sp_matricula_revertir_anulacion`(
+    IN p_id_matricula INT
+)
+BEGIN
+    DECLARE v_estado_actual VARCHAR(20);
+    DECLARE v_curso_sin_vacantes INT DEFAULT 0;
+    DECLARE v_nombre_curso_sin_vacantes VARCHAR(150);
+    DECLARE v_error_message VARCHAR(255);
+    DECLARE done INT DEFAULT FALSE;
+    DECLARE cur_id_curso_programado INT;
+
+    DECLARE cur_cursos CURSOR FOR
+        SELECT id_curso_programado FROM matriculas_detalle WHERE id_matricula = p_id_matricula;
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+    START TRANSACTION;
+
+    SELECT estado INTO v_estado_actual FROM matriculas WHERE id_matricula = p_id_matricula;
+    IF v_estado_actual != 'Anulada' THEN
+        ROLLBACK;
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'La matrícula no se puede revertir porque no está anulada.';
+    END IF;
+
+    OPEN cur_cursos;
+    read_loop: LOOP
+        FETCH cur_cursos INTO cur_id_curso_programado;
+        IF done THEN
+            LEAVE read_loop;
+        END IF;
+
+        SELECT IF(vacantes_disponibles > 0, 0, 1), c.nombre
+        INTO v_curso_sin_vacantes, v_nombre_curso_sin_vacantes
+        FROM cursos_programados cp
+        JOIN cursos c ON cp.id_curso = c.id_curso
+        WHERE cp.id_curso_programado = cur_id_curso_programado;
+
+        IF v_curso_sin_vacantes = 1 THEN
+            SET done = TRUE;
+        END IF;
+    END LOOP;
+    CLOSE cur_cursos;
+
+    IF v_curso_sin_vacantes = 1 THEN
+        SET v_error_message = CONCAT('No se puede revertir. El curso "', v_nombre_curso_sin_vacantes, '" ya no tiene vacantes disponibles.');
+        ROLLBACK;
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = v_error_message;
+    END IF;
+
+    UPDATE matriculas SET estado = 'Activa' WHERE id_matricula = p_id_matricula;
+
+    SET done = FALSE;
+    OPEN cur_cursos;
+    update_loop: LOOP
+        FETCH cur_cursos INTO cur_id_curso_programado;
+        IF done THEN
+            LEAVE update_loop;
+        END IF;
+
+        UPDATE cursos_programados SET vacantes_disponibles = vacantes_disponibles - 1
+        WHERE id_curso_programado = cur_id_curso_programado;
+
+        UPDATE asistencia_cliente ac
+        JOIN matriculas_detalle md ON ac.id_matricula_detalle = md.id_matricula_detalle
+        SET ac.estado = 'Programado'
+        WHERE md.id_matricula = p_id_matricula
+        AND md.id_curso_programado = cur_id_curso_programado
+        AND ac.fecha_clase >= CURDATE()
+        AND ac.estado = 'Cancelado'; -- Solo revertir las que estaban canceladas
+    END LOOP;
+    CLOSE cur_cursos;
+
+    COMMIT;
+END$$
+
+DELIMITER ;

--- a/views/asistencia_clientes/form.php
+++ b/views/asistencia_clientes/form.php
@@ -15,6 +15,9 @@
     <p><strong>Ubicación:</strong> <?php echo htmlspecialchars($detalle_matricula['ubicacion']); ?></p>
 </div>
 
+<div class="page-header-right">
+    <button type="button" id="btn-modificar-asistencia" class="btn btn-warning">Modificar Asistencias</button>
+</div>
 <!-- Attendance Form -->
 <form action="index.php?view=asistencia_clientes&action=guardar" method="POST">
     <input type="hidden" name="id_matricula_detalle" value="<?php echo $id; ?>">
@@ -38,16 +41,22 @@
                         <td>
                             <?php echo date('d/m/Y', strtotime($clase['fecha_clase'])) . ' (' . htmlspecialchars($clase['dia_semana_es']) . ')'; ?>
                         </td>
-                        <td>
-                            <select name="asistencias[<?php echo $clase['id_asistencia_cliente']; ?>][estado]" required>
+                        <td class="cell-estado">
+                            <span class="badge status-<?php echo strtolower(htmlspecialchars($clase['estado'])); ?> view-mode">
+                                <?php echo htmlspecialchars($clase['estado']); ?>
+                            </span>
+                            <select name="asistencias[<?php echo $clase['id_asistencia_cliente']; ?>][estado]" required class="edit-mode" style="display:none;">
                                 <option value="Programado" <?php echo ($clase['estado'] == 'Programado') ? 'selected' : ''; ?>>Programado</option>
                                 <option value="Asistió" <?php echo ($clase['estado'] == 'Asistió') ? 'selected' : ''; ?>>Asistió</option>
                                 <option value="Faltó" <?php echo ($clase['estado'] == 'Faltó') ? 'selected' : ''; ?>>Faltó</option>
                                 <option value="Justificado" <?php echo ($clase['estado'] == 'Justificado') ? 'selected' : ''; ?>>Justificado</option>
+                                <option value="Postergado" <?php echo ($clase['estado'] == 'Postergado') ? 'selected' : ''; ?>>Postergado</option>
+                                <option value="Cancelado" <?php echo ($clase['estado'] == 'Cancelado') ? 'selected' : ''; ?>>Cancelado</option>
                             </select>
                         </td>
-                        <td>
-                            <input type="text" name="asistencias[<?php echo $clase['id_asistencia_cliente']; ?>][observaciones]" value="<?php echo htmlspecialchars($clase['observaciones']); ?>" style="width: 100%;">
+                        <td class="cell-observaciones">
+                            <span class="view-mode"><?php echo htmlspecialchars($clase['observaciones']); ?></span>
+                            <input type="text" name="asistencias[<?php echo $clase['id_asistencia_cliente']; ?>][observaciones]" value="<?php echo htmlspecialchars($clase['observaciones']); ?>" style="width: 100%; display:none;" class="edit-mode">
                         </td>
                     </tr>
                 <?php endforeach; ?>
@@ -72,10 +81,41 @@
         </div>
     <?php endif; ?>
 
-    <div class="form-actions">
+    <div class="form-actions edit-mode" style="display:none;">
         <a href="index.php?view=asistencia_clientes" class="btn btn-secondary">Cancelar</a>
         <button type="submit" class="btn btn-primary">Grabar Asistencia</button>
     </div>
 </form>
+
+<style>
+.badge {
+    padding: 5px 10px;
+    border-radius: 12px;
+    color: #fff;
+    font-weight: bold;
+    font-size: 0.9em;
+    text-shadow: 1px 1px 1px rgba(0,0,0,0.1);
+}
+.status-programado { background-color: #17a2b8; } /* Info */
+.status-asistió { background-color: #28a745; } /* Success */
+.status-faltó { background-color: #dc3545; } /* Danger */
+.status-justificado { background-color: #ffc107; color: #212529; } /* Warning */
+.status-postergado { background-color: #6c757d; } /* Secondary */
+.status-cancelado { background-color: #343a40; } /* Dark */
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const btnModificar = document.getElementById('btn-modificar-asistencia');
+    const viewModeElements = document.querySelectorAll('.view-mode');
+    const editModeElements = document.querySelectorAll('.edit-mode');
+
+    btnModificar.addEventListener('click', function() {
+        viewModeElements.forEach(el => el.style.display = 'none');
+        editModeElements.forEach(el => el.style.display = ''); // Revert to default display
+        this.style.display = 'none'; // Hide the modify button itself
+    });
+});
+</script>
 
 <?php require_once 'views/partials/footer.php'; ?>


### PR DESCRIPTION
Este commit aborda dos problemas en la página de "Asistencia de Clientes": un bug en la lógica de negocio y una solicitud de mejora de la interfaz de usuario.

**1. Corrección del Bug en Estado de Asistencia:**
- Se ha solucionado un bug por el cual el estado de la asistencia no se restauraba correctamente a 'Programado' después de revertir una anulación.
- La causa raíz era una definición de ENUM incompleta en la tabla `asistencia_cliente`, que no incluía el estado 'Cancelado'.
- Se ha creado un nuevo script de base de datos (`bd/update_v1.27_fix_attendance_status.sql`) que:
    - Modifica la tabla `asistencia_cliente` para añadir el estado 'Cancelado'.
    - Redefine los procedimientos `sp_matricula_anular` y `sp_matricula_revertir_anulacion` para asegurar que manejen los estados de forma consistente.

**2. Mejora de la Interfaz de Usuario (UI):**
- Se ha rediseñado la vista para marcar asistencia (`views/asistencia_clientes/form.php`).
- Por defecto, los estados de asistencia ahora se muestran como badges de solo lectura con un código de colores para una fácil identificación visual.
- Se ha añadido un botón "Modificar Asistencias" que permite al usuario entrar en modo de edición, convirtiendo los badges en menús desplegables para poder cambiar los estados.
- Se ha añadido el CSS necesario para los nuevos badges de estado.