### PR TITLE
fix: Corregir visualización de estado en lista de asistencia

### DIFF
--- a/bd/stored_procedures_asistencia_cliente.sql
+++ b/bd/stored_procedures_asistencia_cliente.sql
@@ -40,8 +40,7 @@ BEGIN
     JOIN sub_areas sa ON cp.id_sub_area = sa.id_sub_area
     JOIN areas a ON sa.id_area = a.id_area
     WHERE
-        mc.estado = 1 -- Solo matrículas activas
-        AND (p_id_cliente IS NULL OR md.id_cliente_asistencia = p_id_cliente)
+        (p_id_cliente IS NULL OR md.id_cliente_asistencia = p_id_cliente)
         AND (p_id_curso IS NULL OR cp.id_curso = p_id_curso)
         AND (p_fecha_inicio IS NULL OR cp.fecha_inicio >= p_fecha_inicio)
         AND (p_fecha_fin IS NULL OR cp.fecha_fin <= p_fecha_fin)

--- a/views/asistencia_clientes/list.php
+++ b/views/asistencia_clientes/list.php
@@ -92,8 +92,8 @@
                     <td><?php echo htmlspecialchars($matricula['horas']); ?></td>
                     <td><?php echo htmlspecialchars($matricula['ubicacion']); ?></td>
                     <td>
-                        <span class="badge status-<?php echo ($matricula['estado'] == 1) ? 'activo' : 'anulado'; ?>">
-                            <?php echo ($matricula['estado'] == 1) ? 'Activo' : 'Anulado'; ?>
+                        <span class="badge status-<?php echo strtolower(htmlspecialchars($matricula['estado'])); ?>">
+                            <?php echo htmlspecialchars($matricula['estado']); ?>
                         </span>
                     </td>
                     <td>
@@ -104,5 +104,25 @@
         <?php endif; ?>
     </tbody>
 </table>
+
+<style>
+.badge {
+    padding: 5px 10px;
+    border-radius: 12px;
+    color: #fff;
+    font-weight: bold;
+    font-size: 0.9em;
+    text-shadow: 1px 1px 1px rgba(0,0,0,0.1);
+}
+.status-activa {
+    background-color: #28a745; /* Verde */
+}
+.status-anulada {
+    background-color: #dc3545; /* Rojo */
+}
+.status-completada {
+    background-color: #007bff; /* Azul */
+}
+</style>
 
 <?php require_once 'views/partials/footer.php'; ?>


### PR DESCRIPTION
Este commit soluciona un bug por el cual el estado de una matrícula revertida no se actualizaba correctamente en la vista de "Asistencia de Clientes". También implementa la colorización de los estados en esta vista.

**Correcciones:**

1.  **Stored Procedure:** Se ha modificado el procedimiento `sp_asistencia_cliente_listar_cursos` para que devuelva todas las matrículas, sin filtrar incorrectamente por un estado numérico. Esto asegura que las matrículas anuladas y revertidas aparezcan en la lista.

2.  **Vista de Lista:** Se ha corregido la lógica en `views/asistencia_clientes/list.php` para que muestre el estado de la matrícula directamente desde la base de datos (ej: 'Activa', 'Anulada') en lugar de usar una comprobación numérica.

**Mejoras:**

- Se ha añadido un bloque de CSS a `views/asistencia_clientes/list.php` para aplicar un código de colores a los badges de estado, mejorando la usabilidad y consistencia con otras vistas.