### PR TITLE
feat: Implementar modal reutilizable para validaciones AJAX

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -367,3 +367,111 @@ footer {
 #cursos-seleccionados-grid input[name*="[descuento]"] {
     width: 100px;
 }
+
+/* =================================================================
+   REUSABLE MODAL
+   ================================================================= */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    display: none; /* Oculto por defecto, se activa con JS */
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+.modal-content {
+    background-color: #fff;
+    padding: 25px;
+    border-radius: 8px;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+    width: 90%;
+    max-width: 500px;
+}
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 15px;
+    margin-bottom: 20px;
+}
+.modal-header h2 {
+    margin: 0;
+    font-size: 1.5em;
+}
+.modal-close {
+    cursor: pointer;
+    font-size: 1.8em;
+    font-weight: bold;
+    border: none;
+    background: none;
+    padding: 0;
+    line-height: 1;
+}
+.modal-body {
+    margin-bottom: 20px;
+}
+.modal-footer {
+    text-align: right;
+    border-top: 1px solid #eee;
+    padding-top: 20px;
+    margin-top: 20px;
+}
+
+/* =================================================================
+   REUSABLE MODAL
+   ================================================================= */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    display: none; /* Oculto por defecto, se activa con JS */
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+.modal-content {
+    background-color: #fff;
+    padding: 25px;
+    border-radius: 8px;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+    width: 90%;
+    max-width: 500px;
+}
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 15px;
+    margin-bottom: 20px;
+}
+.modal-header h2 {
+    margin: 0;
+    font-size: 1.5em;
+}
+.modal-close {
+    cursor: pointer;
+    font-size: 1.8em;
+    font-weight: bold;
+    border: none;
+    background: none;
+    padding: 0;
+    line-height: 1;
+}
+.modal-body {
+    margin-bottom: 20px;
+}
+.modal-footer {
+    text-align: right;
+    border-top: 1px solid #eee;
+    padding-top: 20px;
+    margin-top: 20px;
+}

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -70,4 +70,34 @@ document.addEventListener('DOMContentLoaded', function() {
             clienteForm.submit();
         });
     }
+
+    // --- Lógica para el Modal de Error Reutilizable ---
+    // Esta lógica asume que el HTML del modal está presente en la página.
+    const modal = document.getElementById('error-modal');
+    if (modal) {
+        const modalMessage = document.getElementById('error-modal-message');
+        const modalTitle = document.getElementById('error-modal-title');
+        const closeButtons = document.querySelectorAll('.modal-close');
+
+        // Crear un objeto global para controlar el modal desde otros scripts
+        window.AppModal = {
+            show: function(message, title = 'Error') {
+                modalMessage.textContent = message;
+                modalTitle.textContent = title;
+                modal.style.display = 'flex';
+            },
+            hide: function() {
+                modal.style.display = 'none';
+            }
+        };
+
+        // Event listeners para cerrar el modal
+        closeButtons.forEach(button => button.addEventListener('click', window.AppModal.hide));
+        modal.addEventListener('click', function(event) {
+            // Cerrar si se hace clic en el overlay
+            if (event.target === modal) {
+                window.AppModal.hide();
+            }
+        });
+    }
 });

--- a/views/partials/modal_error.php
+++ b/views/partials/modal_error.php
@@ -1,0 +1,15 @@
+<!-- Reusable Error Modal -->
+<div id="error-modal" class="modal-overlay" style="display: none;">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h2 id="error-modal-title">Error</h2>
+            <span class="modal-close">&times;</span>
+        </div>
+        <div class="modal-body">
+            <p id="error-modal-message"></p>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn btn-primary modal-close">Entendido</button>
+        </div>
+    </div>
+</div>

--- a/views/sub_areas/form.php
+++ b/views/sub_areas/form.php
@@ -17,7 +17,7 @@ $action_url = $is_edit ? 'index.php?view=sub_areas&action=update' : 'index.php?v
 <?php endif; ?>
 
 <div class="form-container">
-    <form action="<?php echo $action_url; ?>" method="POST">
+    <form action="<?php echo $action_url; ?>" method="POST" id="sub-area-form">
 
         <?php if ($is_edit): ?>
             <input type="hidden" name="id_sub_area" value="<?php echo $item_a_editar['id_sub_area']; ?>">
@@ -60,32 +60,29 @@ $action_url = $is_edit ? 'index.php?view=sub_areas&action=update' : 'index.php?v
     </form>
 </div>
 
+<?php require_once 'views/partials/modal_error.php'; // Incluir el modal reutilizable ?>
+
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    const form = document.querySelector('form');
-    // Solo aplicar la lógica AJAX si estamos en modo de edición
+    const form = document.getElementById('sub-area-form');
     const isEditMode = <?php echo json_encode($is_edit); ?>;
 
-    if (isEditMode) {
-        let isSubmitting = false; // Flag para evitar bucles
+    // Solo ejecutar el script de validación AJAX en modo de edición y si el modal global existe
+    if (isEditMode && window.AppModal) {
+        let isSubmitting = false;
 
         form.addEventListener('submit', function(event) {
-            // Si ya estamos en proceso de envío (después de la validación AJAX), no hacer nada más.
-            if (isSubmitting) {
-                return;
-            }
-
-            event.preventDefault(); // Detener el envío inicial
+            if (isSubmitting) return;
+            event.preventDefault();
 
             const idSubAreaInput = form.querySelector('input[name="id_sub_area"]');
             const capacidadInput = form.querySelector('input[name="capacidad_maxima"]');
-
             const data = new FormData();
             data.append('id_sub_area', idSubAreaInput.value);
             data.append('capacidad', capacidadInput.value);
 
-            // Deshabilitar el botón de envío para evitar clics múltiples
             const submitButton = form.querySelector('button[type="submit"]');
+            const originalButtonText = submitButton.textContent;
             submitButton.disabled = true;
             submitButton.textContent = 'Validando...';
 
@@ -96,21 +93,20 @@ document.addEventListener('DOMContentLoaded', function() {
             .then(response => response.json())
             .then(result => {
                 if (result.success) {
-                    // Si la validación es exitosa, marcar como "enviando" y reenviar el formulario
                     isSubmitting = true;
                     form.submit();
                 } else {
-                    // Si hay un error, mostrar el mensaje y reactivar el botón
-                    alert('Error de validación:\n' + result.message);
+                    // Usar el modal global para mostrar el error
+                    window.AppModal.show(result.message, 'Error de Validación de Capacidad');
                     submitButton.disabled = false;
-                    submitButton.textContent = 'Actualizar Sub Área';
+                    submitButton.textContent = originalButtonText;
                 }
             })
             .catch(error => {
                 console.error('Error en la llamada AJAX:', error);
-                alert('Ocurrió un error al contactar al servidor. Por favor, intente de nuevo.');
+                window.AppModal.show('Ocurrió un error al contactar al servidor. Por favor, intente de nuevo.');
                 submitButton.disabled = false;
-                submitButton.textContent = 'Actualizar Sub Área';
+                submitButton.textContent = originalButtonText;
             });
         });
     }


### PR DESCRIPTION
Se ha refactorizado la validación de capacidad de sub-áreas para utilizar un diálogo modal reutilizable en lugar de un `alert()` de JavaScript, mejorando la experiencia de usuario.

**Cambios Realizados:**

1.  **Componente Modal Parcial:** Se ha creado un nuevo archivo `views/partials/modal_error.php` que contiene la estructura HTML de un modal genérico para errores.
2.  **CSS Global:** Los estilos para el modal se han añadido al archivo global `public/assets/css/style.css` para que estén disponibles en todo el sistema.
3.  **JavaScript Global:** Se ha añadido un objeto `window.AppModal` al archivo `public/assets/js/main.js`, proporcionando funciones globales (`show`, `hide`) para controlar el modal desde cualquier página.
4.  **Refactorización del Formulario:** La vista `views/sub_areas/form.php` ha sido actualizada para incluir el nuevo parcial del modal y utilizar las funciones globales de JavaScript para mostrar los errores de validación de la capacidad.

Este cambio no solo mejora la interfaz de la validación de sub-áreas, sino que también proporciona un componente modal robusto y reutilizable para futuras validaciones AJAX en otras partes del sistema.