### PR TITLE
fix: Actualizar texto del botón en el modal de error

### DIFF
--- a/views/partials/modal_error.php
+++ b/views/partials/modal_error.php
@@ -9,7 +9,7 @@
             <p id="error-modal-message"></p>
         </div>
         <div class="modal-footer">
-            <button type="button" class="btn btn-primary modal-close">Entendido</button>
+            <button type="button" class="btn btn-primary modal-close">Aceptar</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Se ha actualizado el texto del botón en el diálogo modal reutilizable, cambiando "Entendido" por "Aceptar" según la solicitud del usuario.

El botón ya utilizaba la clase `btn-primary`, que le asigna el color de fondo azul definido en el CSS global, por lo que no se necesitaron cambios de estilo.