### PR TITLE
fix: Corregir visibilidad y tamaño del botón del modal

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -421,6 +421,10 @@ footer {
     padding-top: 20px;
     margin-top: 20px;
 }
+.modal-footer .btn {
+    padding: 8px 16px;
+    font-size: 0.9em;
+}
 
 /* =================================================================
    REUSABLE MODAL

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -10,7 +10,8 @@ const modal = document.getElementById('error-modal');
 if (modal) {
     const modalMessage = document.getElementById('error-modal-message');
     const modalTitle = document.getElementById('error-modal-title');
-    const closeButtons = document.querySelectorAll('.modal-close');
+    const closeButtons = document.querySelectorAll('.modal-close'); // Gets the 'X'
+    const acceptButton = document.getElementById('modal-accept-button'); // Gets the 'Aceptar' button
 
     // Crear un objeto global para controlar el modal desde otros scripts
     window.AppModal = {
@@ -26,6 +27,9 @@ if (modal) {
 
     // Event listeners para cerrar el modal
     closeButtons.forEach(button => button.addEventListener('click', window.AppModal.hide));
+    if (acceptButton) {
+        acceptButton.addEventListener('click', window.AppModal.hide);
+    }
     modal.addEventListener('click', function(event) {
         // Cerrar si se hace clic en el overlay
         if (event.target === modal) {

--- a/views/partials/modal_error.php
+++ b/views/partials/modal_error.php
@@ -9,7 +9,7 @@
             <p id="error-modal-message"></p>
         </div>
         <div class="modal-footer">
-            <button type="button" class="btn btn-primary modal-close">Aceptar</button>
+            <button type="button" class="btn btn-primary" id="modal-accept-button">Aceptar</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Este commit soluciona un bug visual en el diálogo modal reutilizable donde el botón "Aceptar" era invisible por defecto. También ajusta el tamaño del botón según la solicitud del usuario.

**Correcciones:**

1.  **Conflicto de Clases CSS:** Se ha eliminado la clase `modal-close` del botón "Aceptar" en `views/partials/modal_error.php`. Esta clase, destinada al botón 'X', aplicaba un `background: none` que hacía invisible al botón principal.
2.  **Actualización de JavaScript:** El script en `public/assets/js/main.js` ha sido actualizado para que siga asociando la acción de cerrar el modal tanto al botón 'X' como al botón "Aceptar", ahora identificado por su ID.
3.  **Ajuste de Tamaño:** Se ha añadido una nueva regla CSS en `public/assets/css/style.css` para reducir el tamaño del padding y la fuente del botón en el pie del modal, haciéndolo menos prominente.