### PR TITLE
feat: Añadir colores a los estados en la lista de asistencia de profe…

### DIFF
--- a/views/asistencia_profesor/list.php
+++ b/views/asistencia_profesor/list.php
@@ -103,4 +103,27 @@
     </tbody>
 </table>
 
+<style>
+.badge {
+    padding: 5px 10px;
+    border-radius: 12px;
+    color: #fff;
+    font-weight: bold;
+    font-size: 0.9em;
+    text-shadow: 1px 1px 1px rgba(0,0,0,0.1);
+}
+.status-programado {
+    background-color: #17a2b8; /* Azul (Info) */
+}
+.status-en { /* Para "En Curso" */
+    background-color: #28a745; /* Verde (Activo) */
+}
+.status-finalizado {
+    background-color: #6c757d; /* Gris (Secundario) */
+}
+.status-cancelado {
+    background-color: #dc3545; /* Rojo (Peligro) */
+}
+</style>
+
 <?php require_once 'views/partials/footer.php'; ?>


### PR DESCRIPTION
…sores

Se ha añadido un bloque de CSS a la vista `views/asistencia_profesor/list.php` para aplicar un código de colores a los badges de estado del curso programado.

Este cambio mejora la consistencia visual de la aplicación, utilizando el mismo estilo de badges de colores que se ha implementado en otras vistas de gestión.

Los colores aplicados son:
- Azul para 'Programado'
- Verde para 'En Curso'
- Gris para 'Finalizado'
- Rojo para 'Cancelado'