### PR TITLE
fix(calendar): Add event times and prevent text overflow

### DIFF
--- a/views/calendario/calendario_view.php
+++ b/views/calendario/calendario_view.php
@@ -15,16 +15,26 @@
         font-size: 12px;
         line-height: 1.3;
         cursor: pointer;
+        /* Corrección de desbordamiento */
+        overflow: hidden;
+    }
+    .fc-event-title, .event-details p, .event-time {
+        /* Evitar que el texto se divida y se desborde */
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
     .fc-event-title {
         font-weight: bold;
-        white-space: normal; /* Permitir que el título del curso se divida en varias líneas */
     }
     .event-details {
         margin-top: 5px;
     }
     .event-details p {
         margin: 0;
+    }
+    .event-time {
+        font-weight: bold;
     }
 </style>
 
@@ -42,9 +52,15 @@ document.addEventListener('DOMContentLoaded', function() {
             hash = key.charCodeAt(i) + ((hash << 5) - hash);
         }
         const h = hash % 360;
-        // Usar HSL para colores pastel: alta luminosidad (l), saturación media (s)
         return `hsl(${h}, 70%, 85%)`;
     }
+
+    // --- Formateador de hora ---
+    const timeFormatter = new Intl.DateTimeFormat('es-ES', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+    });
 
     var calendarEl = document.getElementById('calendar');
     var calendar = new FullCalendar.Calendar(calendarEl, {
@@ -55,7 +71,6 @@ document.addEventListener('DOMContentLoaded', function() {
             center: 'title',
             right: 'dayGridMonth,timeGridWeek,timeGridDay'
         },
-        // Cargar los eventos desde la variable PHP
         events: <?php echo $calendar_events_json; ?>,
 
         eventContent: function(arg) {
@@ -63,12 +78,19 @@ document.addEventListener('DOMContentLoaded', function() {
             const key = `${props.id_curso}-${props.id_area}-${props.id_sub_area}-${props.id_cliente}`;
             const color = generatePastelColor(key);
 
+            // Formatear la hora
+            const startTime = timeFormatter.format(arg.event.start);
+            const endTime = timeFormatter.format(arg.event.end);
+            const timeText = `${startTime} - ${endTime}`;
+
             let eventEl = document.createElement('div');
             eventEl.style.backgroundColor = color;
             eventEl.style.borderColor = color;
             eventEl.classList.add('fc-event-main-frame');
 
+            // Añadir la hora antes del título
             eventEl.innerHTML = `
+                <div class="event-time">${timeText}</div>
                 <div class="fc-event-title-container">
                     <div class="fc-event-title">${arg.event.title}</div>
                 </div>


### PR DESCRIPTION
This commit addresses user feedback on the calendar view:

1.  The event display has been updated to include the start and end times (e.g., '10:00 - 12:00') before the course title.
2.  CSS has been added to prevent text from overflowing the event cell on smaller calendar views. Long text will now be truncated with an ellipsis.