### PR TITLE
feat(calendar): Add programmed courses calendar view

### DIFF
--- a/bd/update_v1.32_calendar_cursos_sp.sql
+++ b/bd/update_v1.32_calendar_cursos_sp.sql
@@ -1,0 +1,55 @@
+-- =================================================================
+-- Script de Actualización de la Base de Datos - Versión 1.32
+-- Añade SP para el nuevo calendario de cursos programados.
+-- =================================================================
+
+USE `academia_cursos`;
+
+DELIMITER $$
+
+-- -----------------------------------------------------
+-- `sp_calendario_programacion_listar`
+-- Lista todos los cursos programados con datos extendidos
+-- para ser usados por el nuevo "Calendario de Cursos".
+-- -----------------------------------------------------
+
+DROP PROCEDURE IF EXISTS `sp_calendario_programacion_listar`$$
+CREATE PROCEDURE `sp_calendario_programacion_listar`(
+    IN p_id_profesor INT,
+    IN p_id_curso INT,
+    IN p_fecha_inicio DATE,
+    IN p_fecha_fin DATE
+)
+BEGIN
+    SELECT
+        cp.id_curso_programado,
+        c.id_curso,
+        c.nombre AS curso_nombre,
+        p.id_profesor,
+        CONCAT(p.nombres, ' ', p.apellidos) AS profesor_nombre,
+        a.id_area,
+        sa.id_sub_area,
+        CONCAT(a.nombre, ' - ', sa.descripcion, ' ', sa.numero_sub_area) AS ubicacion,
+        th.descripcion AS tipo_horario_nombre,
+        th.dias_semana,
+        cp.fecha_inicio,
+        cp.fecha_fin,
+        cp.hora_inicio,
+        cp.hora_fin,
+        cp.vacantes_disponibles,
+        cp.estado
+    FROM cursos_programados cp
+    JOIN cursos c ON cp.id_curso = c.id_curso
+    JOIN profesores p ON cp.id_profesor = p.id_profesor
+    JOIN tipos_horario th ON cp.id_tipo_horario = th.id_tipo_horario
+    JOIN sub_areas sa ON cp.id_sub_area = sa.id_sub_area
+    JOIN areas a ON sa.id_area = a.id_area
+    WHERE
+        (p_id_profesor IS NULL OR cp.id_profesor = p_id_profesor)
+        AND (p_id_curso IS NULL OR cp.id_curso = p_id_curso)
+        AND (p_fecha_inicio IS NULL OR cp.fecha_inicio >= p_fecha_inicio)
+        AND (p_fecha_fin IS NULL OR cp.fecha_fin <= p_fecha_fin)
+    ORDER BY cp.fecha_inicio DESC;
+END$$
+
+DELIMITER ;

--- a/controllers/calendario_cursos_controller.php
+++ b/controllers/calendario_cursos_controller.php
@@ -1,0 +1,74 @@
+<?php
+// =================================================================
+// Controlador para el Calendario de Cursos Programados
+// =================================================================
+
+// --- Verificación de Seguridad ---
+Session::check();
+// ---------------------------------
+
+require_once 'models/CalendarioCursosModel.php';
+
+$calendarioCursosModel = new CalendarioCursosModel();
+$cursos_programados = $calendarioCursosModel->obtenerCursosProgramados();
+
+$calendar_events = [];
+$filter_data = [
+    'cursos' => [],
+    'profesores' => [],
+    'ubicaciones' => []
+];
+
+foreach ($cursos_programados as $curso) {
+    // --- Preparar datos para los filtros ---
+    if (!isset($filter_data['cursos'][$curso['id_curso']])) {
+        $filter_data['cursos'][$curso['id_curso']] = $curso['curso_nombre'];
+    }
+    if (!isset($filter_data['profesores'][$curso['profesor_nombre']])) {
+        $filter_data['profesores'][$curso['profesor_nombre']] = $curso['profesor_nombre'];
+    }
+    if (!isset($filter_data['ubicaciones'][$curso['ubicacion']])) {
+        $filter_data['ubicaciones'][$curso['ubicacion']] = $curso['ubicacion'];
+    }
+
+    // --- Preparar eventos para el calendario ---
+    $fecha_inicio = new DateTime($curso['fecha_inicio']);
+    $fecha_fin = new DateTime($curso['fecha_fin']);
+    $dias_semana = explode(',', $curso['dias_semana']);
+
+    $intervalo = new DateInterval('P1D');
+    $periodo = new DatePeriod($fecha_inicio, $intervalo, $fecha_fin->modify('+1 day'));
+
+    foreach ($periodo as $fecha) {
+        if (in_array($fecha->format('N'), $dias_semana)) {
+            $start_datetime = $fecha->format('Y-m-d') . 'T' . $curso['hora_inicio'];
+            $end_datetime = $fecha->format('Y-m-d') . 'T' . $curso['hora_fin'];
+
+            $calendar_events[] = [
+                'title' => $curso['curso_nombre'],
+                'start' => $start_datetime,
+                'end' => $end_datetime,
+                'extendedProps' => [
+                    'id_curso' => $curso['id_curso'],
+                    'id_area' => $curso['id_area'],
+                    'id_sub_area' => $curso['id_sub_area'],
+                    'nombre_profesor' => $curso['profesor_nombre'],
+                    'ubicacion' => $curso['ubicacion'],
+                    'vacantes' => $curso['vacantes_disponibles']
+                ]
+            ];
+        }
+    }
+}
+
+// Ordenar los datos de los filtros alfabéticamente
+asort($filter_data['cursos']);
+asort($filter_data['profesores']);
+asort($filter_data['ubicaciones']);
+
+
+// Convertir el array de eventos a JSON para pasarlo a JavaScript
+$calendar_events_json = json_encode($calendar_events);
+
+// Cargar la vista del calendario
+require_once 'views/calendario_cursos/calendario_cursos_view.php';

--- a/models/CalendarioCursosModel.php
+++ b/models/CalendarioCursosModel.php
@@ -1,0 +1,29 @@
+<?php
+// =================================================================
+// Modelo CalendarioCursos: Gestiona los datos para el calendario
+// de cursos programados.
+// =================================================================
+
+class CalendarioCursosModel {
+    private $db;
+
+    public function __construct() {
+        $this->db = Database::getInstance();
+    }
+
+    /**
+     * Obtiene todos los cursos programados para el calendario.
+     * @return array Lista de cursos programados.
+     */
+    public function obtenerCursosProgramados() {
+        try {
+            // Llamar al nuevo SP que devuelve datos extendidos.
+            // No se necesitan filtros para el calendario general.
+            $this->db->callStoredProcedure('sp_calendario_programacion_listar', [null, null, null, null]);
+            return $this->db->resultSet();
+        } catch (Exception $e) {
+            error_log("Error en CalendarioCursosModel::obtenerCursosProgramados: " . $e->getMessage());
+            return [];
+        }
+    }
+}

--- a/views/calendario_cursos/calendario_cursos_view.php
+++ b/views/calendario_cursos/calendario_cursos_view.php
@@ -1,0 +1,209 @@
+<?php require_once 'views/partials/header.php'; ?>
+
+<div class="page-header">
+    <h1>Calendario de Cursos Programados</h1>
+</div>
+
+<!-- Filtros del Calendario -->
+<div class="card" style="padding: 20px; margin-bottom: 20px;">
+    <div class="filter-container">
+        <div class="form-group">
+            <label for="filtro_curso">Curso:</label>
+            <select id="filtro_curso" class="form-control">
+                <option value="">Todos</option>
+                <?php foreach ($filter_data['cursos'] as $id => $nombre): ?>
+                    <option value="<?php echo $id; ?>"><?php echo htmlspecialchars($nombre); ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="filtro_profesor">Profesor:</label>
+            <select id="filtro_profesor" class="form-control">
+                <option value="">Todos</option>
+                <?php foreach ($filter_data['profesores'] as $nombre): ?>
+                    <option value="<?php echo htmlspecialchars($nombre); ?>"><?php echo htmlspecialchars($nombre); ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="filtro_ubicacion">Ubicación:</label>
+            <select id="filtro_ubicacion" class="form-control">
+                <option value="">Todas</option>
+                <?php foreach ($filter_data['ubicaciones'] as $nombre): ?>
+                    <option value="<?php echo htmlspecialchars($nombre); ?>"><?php echo htmlspecialchars($nombre); ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="form-group filter-buttons">
+            <button id="btn_filtrar" type="button" class="btn btn-primary">Filtrar</button>
+            <button id="btn_limpiar" type="button" class="btn btn-secondary">Limpiar</button>
+        </div>
+    </div>
+</div>
+
+
+<div class="card" style="padding: 20px;">
+    <div id="calendar"></div>
+</div>
+
+<style>
+    .filter-container {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+        gap: 15px;
+        align-items: flex-end;
+    }
+    .form-group {
+        display: flex;
+        flex-direction: column;
+    }
+    .form-group label {
+        margin-bottom: 5px;
+        font-weight: bold;
+    }
+    .form-control {
+        width: 100%;
+        padding: 8px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+    }
+    .filter-buttons {
+        flex-direction: row;
+        gap: 10px;
+    }
+
+    /* Estilos para los eventos del calendario */
+    .fc-event-main-frame {
+        padding: 5px;
+        font-size: 12px;
+        line-height: 1.3;
+        cursor: pointer;
+        overflow: hidden;
+    }
+    .fc-event-title, .event-details p, .event-time {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+    .fc-event-title {
+        font-weight: bold;
+    }
+    .event-details {
+        margin-top: 5px;
+    }
+    .event-details p {
+        margin: 0;
+    }
+    .event-time {
+        font-weight: bold;
+    }
+</style>
+
+<!-- FullCalendar JS -->
+<script src='https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.js'></script>
+<script src='https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/locales/es.js'></script>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+
+    // --- Variables y referencias ---
+    const allEvents = <?php echo $calendar_events_json; ?>;
+    const calendarEl = document.getElementById('calendar');
+    const filtroCurso = document.getElementById('filtro_curso');
+    const filtroProfesor = document.getElementById('filtro_profesor');
+    const filtroUbicacion = document.getElementById('filtro_ubicacion');
+    const btnFiltrar = document.getElementById('btn_filtrar');
+    const btnLimpiar = document.getElementById('btn_limpiar');
+
+    // --- Función para generar colores pastel ---
+    function generatePastelColor(str) {
+        let hash = 0x811c9dc5;
+        for (let i = 0; i < str.length; i++) {
+            hash ^= str.charCodeAt(i);
+            hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+        }
+        const h = (hash >>> 0) % 360;
+        return `hsl(${h}, 70%, 85%)`;
+    }
+
+    // --- Formateador de hora ---
+    const timeFormatter = new Intl.DateTimeFormat('es-ES', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+    });
+
+    // --- Inicialización del Calendario ---
+    var calendar = new FullCalendar.Calendar(calendarEl, {
+        initialView: 'dayGridMonth',
+        locale: 'es',
+        headerToolbar: {
+            left: 'prev,next today',
+            center: 'title',
+            right: 'dayGridMonth,timeGridWeek,timeGridDay'
+        },
+        events: allEvents,
+
+        eventContent: function(arg) {
+            const props = arg.event.extendedProps;
+            // La clave de color no incluye al cliente
+            const key = `${props.id_curso}-${props.id_area}-${props.id_sub_area}`;
+            const color = generatePastelColor(key);
+
+            const startTime = timeFormatter.format(arg.event.start);
+            const endTime = timeFormatter.format(arg.event.end);
+            const timeText = `${startTime} - ${endTime}`;
+
+            let eventEl = document.createElement('div');
+            eventEl.style.backgroundColor = color;
+            eventEl.style.borderColor = color;
+            eventEl.classList.add('fc-event-main-frame');
+
+            eventEl.innerHTML = `
+                <div class="event-time">${timeText}</div>
+                <div class="fc-event-title-container">
+                    <div class="fc-event-title">${arg.event.title}</div>
+                </div>
+                <div class="event-details">
+                    <p><strong>Prof:</strong> ${props.nombre_profesor}</p>
+                    <p><strong>Ubic:</strong> ${props.ubicacion}</p>
+                    <p><strong>Vacantes:</strong> ${props.vacantes}</p>
+                </div>
+            `;
+
+            return { domNodes: [eventEl] };
+        }
+    });
+    calendar.render();
+
+    // --- Lógica de los Filtros ---
+    btnFiltrar.addEventListener('click', function() {
+        const cursoId = filtroCurso.value;
+        const profesorNombre = filtroProfesor.value;
+        const ubicacionNombre = filtroUbicacion.value;
+
+        const filteredEvents = allEvents.filter(function(event) {
+            const props = event.extendedProps;
+            const matchCurso = !cursoId || props.id_curso == cursoId;
+            const matchProfesor = !profesorNombre || props.nombre_profesor == profesorNombre;
+            const matchUbicacion = !ubicacionNombre || props.ubicacion == ubicacionNombre;
+
+            return matchCurso && matchProfesor && matchUbicacion;
+        });
+
+        calendar.removeAllEvents();
+        calendar.addEventSource(filteredEvents);
+    });
+
+    btnLimpiar.addEventListener('click', function() {
+        filtroCurso.value = "";
+        filtroProfesor.value = "";
+        filtroUbicacion.value = "";
+
+        calendar.removeAllEvents();
+        calendar.addEventSource(allEvents);
+    });
+});
+</script>
+
+<?php require_once 'views/partials/footer.php'; ?>

--- a/views/partials/header.php
+++ b/views/partials/header.php
@@ -50,6 +50,7 @@ $base_url = defined('SITE_URL') ? SITE_URL : '';
                     <li><a href="<?php echo $base_url; ?>index.php?view=asistencia_profesores">Asistencia Profesores</a></li>
                     <li><a href="<?php echo $base_url; ?>index.php?view=asistencia_clientes">Asistencia Clientes</a></li>
                     <li><a href="<?php echo $base_url; ?>index.php?view=calendario">Calendario</a></li>
+                    <li><a href="<?php echo $base_url; ?>index.php?view=calendario_cursos">Calendario de Cursos</a></li>
                 </ul>
             </li>
 


### PR DESCRIPTION
This commit introduces a new 'Calendario de Cursos' page, accessible from the 'Operaciones' menu.

This new calendar provides a view of all scheduled courses, as they appear on the 'Programación de Horarios' page, allowing for a visual overview of the month's schedule.

Key changes include:
- A new menu item and route for `index.php?view=calendario_cursos`.
- A new stored procedure `sp_calendario_programacion_listar` to fetch all necessary data for scheduled courses.
- A new `CalendarioCursosModel` and `calendario_cursos_controller` to handle the data and logic for the new page.
- A new `calendario_cursos_view` that adapts the existing calendar functionality. The color-coding is based on course, area, and sub-area (excluding the client), and the event details show vacancy information.
- Filters for course, professor, and location have been included.