### PR TITLE
fix(routing): Add calendario_cursos to router whitelist

### DIFF
--- a/index.php
+++ b/index.php
@@ -44,7 +44,7 @@ $allowed_views = [
     // Vistas de Mantenimientos (Configuración)
     'usuarios', 'clientes', 'cursos', 'areas', 'sub_areas', 'profesores', 'tipos_area', 'tipos_documento', 'formas_pago', 'tipos_curso', 'tipos_precio', 'tipos_horario', 'lista_precios',
     // Vistas de Operaciones
-    'monitor', 'programar_horarios', 'asistencia_profesores', 'asistencia_clientes', 'calendario',
+    'monitor', 'programar_horarios', 'asistencia_profesores', 'asistencia_clientes', 'calendario', 'calendario_cursos',
     // Vistas de Matrícula
     'matriculas', 'matricula_nueva'
 ];


### PR DESCRIPTION
This commit fixes a 404 error that occurred when accessing the new 'Calendario de Cursos' page.

The `index.php` front controller uses a whitelist for allowed views, and the new 'calendario_cursos' view was missing from this list. This commit adds it to the `$allowed_views` array, resolving the routing issue.