### PR TITLE
feat(matricula): Add inline client creation from enrollment page

### DIFF
--- a/controllers/clientes_controller.php
+++ b/controllers/clientes_controller.php
@@ -103,6 +103,39 @@ try {
             }
             break;
 
+        case 'crear_ajax':
+            // Endpoint para creación de cliente vía AJAX desde la página de matrícula
+            header('Content-Type: application/json');
+            if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                $datos = [
+                    'id_tipo_documento' => $_POST['id_tipo_documento'],
+                    'numero_documento' => $_POST['numero_documento'],
+                    'nombres' => $_POST['nombres'],
+                    'apellidos' => $_POST['apellidos'],
+                    'email' => $_POST['email'] ?? null,
+                    'telefono' => $_POST['telefono'] ?? null,
+                    'codigo_erp' => $_POST['codigo_erp'] ?? null
+                ];
+
+                // Validaciones básicas del lado del servidor
+                if (empty($datos['nombres']) || empty($datos['apellidos']) || empty($datos['numero_documento'])) {
+                    echo json_encode(['success' => false, 'error' => 'Nombres, apellidos y número de documento son obligatorios.']);
+                    exit();
+                }
+
+                $resultado = $clienteModel->crear($datos);
+
+                if ($resultado['success']) {
+                    $nuevo_cliente = $clienteModel->obtenerPorId($resultado['id']);
+                    echo json_encode(['success' => true, 'cliente' => $nuevo_cliente]);
+                } else {
+                    echo json_encode(['success' => false, 'error' => 'Error al crear el cliente: ' . $resultado['error']]);
+                }
+            } else {
+                echo json_encode(['success' => false, 'error' => 'Método no permitido.']);
+            }
+            exit();
+
         case 'check_documento':
             // Endpoint para validación AJAX
             header('Content-Type: application/json');

--- a/controllers/matriculas_controller.php
+++ b/controllers/matriculas_controller.php
@@ -30,6 +30,11 @@ switch ($action) {
         break;
 
     case 'nueva':
+        // Cargar datos adicionales para el formulario, como los tipos de documento
+        require_once 'models/TiposDocumentoModel.php';
+        $tiposDocumentoModel = new TiposDocumentoModel();
+        $tipos_documento = $tiposDocumentoModel->obtenerTodos();
+
         // Cargar la vista principal del formulario
         require_once 'views/matriculas/nueva.php';
         break;

--- a/public/assets/js/matricula_form.js
+++ b/public/assets/js/matricula_form.js
@@ -1,7 +1,15 @@
 // =================================================================
-// Lógica JavaScript para la página de Nueva Matrícula
+// Lógica JavaScript para la página de Nueva Matrícula (v2 con modal)
 // =================================================================
 document.addEventListener('DOMContentLoaded', function() {
+
+    // --- Referencias a elementos del Modal ---
+    const modal = document.getElementById('modal-nuevo-cliente');
+    const btnNuevoCliente = document.getElementById('btn-nuevo-cliente');
+    const btnCerrarModal = document.getElementById('modal-close-btn');
+    const btnCancelarModal = document.getElementById('modal-cancel-btn');
+    const formNuevoCliente = document.getElementById('form-nuevo-cliente');
+    const modalErrorMessage = document.getElementById('modal-error-message');
 
     // --- Lógica para la Sección 1: Búsqueda de Cliente Principal ---
     const inputBuscarCliente = document.getElementById('buscar-cliente');
@@ -13,6 +21,9 @@ document.addEventListener('DOMContentLoaded', function() {
     inputBuscarCliente.addEventListener('keyup', function() {
         clearTimeout(mainClientSearchTimeout);
         const query = this.value;
+
+        // Ocultar el botón de nuevo cliente al empezar a escribir
+        btnNuevoCliente.style.display = 'none';
 
         if (query.length < 2) { resultsContainer.innerHTML = ''; return; }
 
@@ -36,12 +47,15 @@ document.addEventListener('DOMContentLoaded', function() {
                                 infoCliente.textContent = `Cliente Seleccionado: ${this.dataset.nombre}`;
                                 inputBuscarCliente.value = this.dataset.nombre;
                                 resultsContainer.innerHTML = '';
+                                btnNuevoCliente.style.display = 'none';
                             });
                             list.appendChild(item);
                         });
                         resultsContainer.appendChild(list);
                     } else {
                         resultsContainer.innerHTML = '<div class="search-results-list"><div class="search-results-item">No se encontraron clientes.</div></div>';
+                        // Mostrar el botón si no hay resultados
+                        btnNuevoCliente.style.display = 'block';
                     }
                 })
                 .catch(error => console.error('Error en la búsqueda de clientes:', error));
@@ -54,8 +68,60 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
+    // --- Lógica del Modal de Nuevo Cliente ---
+    btnNuevoCliente.addEventListener('click', function() {
+        modal.style.display = 'flex';
+    });
 
-    // --- Lógica para la Sección 2: Búsqueda y Selección de Cursos ---
+    function cerrarModal() {
+        modal.style.display = 'none';
+        formNuevoCliente.reset();
+        modalErrorMessage.style.display = 'none';
+        modalErrorMessage.textContent = '';
+    }
+
+    btnCerrarModal.addEventListener('click', cerrarModal);
+    btnCancelarModal.addEventListener('click', cerrarModal);
+
+    formNuevoCliente.addEventListener('submit', function(e) {
+        e.preventDefault();
+        modalErrorMessage.style.display = 'none';
+
+        const formData = new FormData(this);
+
+        fetch('index.php?view=clientes&action=crear_ajax', {
+            method: 'POST',
+            body: formData
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.success && data.cliente) {
+                // Éxito: poblar el formulario principal
+                const cliente = data.cliente;
+                hiddenIdCliente.value = cliente.id_cliente;
+                const nombreCompleto = `${cliente.nombres} ${cliente.apellidos}`;
+                infoCliente.textContent = `Cliente Seleccionado: ${nombreCompleto}`;
+                inputBuscarCliente.value = nombreCompleto;
+
+                resultsContainer.innerHTML = '';
+                btnNuevoCliente.style.display = 'none';
+
+                cerrarModal();
+            } else {
+                // Error: mostrar mensaje en el modal
+                modalErrorMessage.textContent = data.error || 'Ocurrió un error desconocido.';
+                modalErrorMessage.style.display = 'block';
+            }
+        })
+        .catch(error => {
+            console.error('Error en la creación del cliente:', error);
+            modalErrorMessage.textContent = 'Error de conexión. Inténtelo de nuevo.';
+            modalErrorMessage.style.display = 'block';
+        });
+    });
+
+
+    // --- Lógica para la Sección 2: Búsqueda y Selección de Cursos (sin cambios) ---
     const btnBuscarCursos = document.getElementById('btn-buscar-cursos');
     const cursosContainer = document.getElementById('cursos-disponibles-container');
     const cursosSeleccionadosBody = document.querySelector('#cursos-seleccionados-grid tbody');
@@ -98,7 +164,6 @@ document.addEventListener('DOMContentLoaded', function() {
                     data.forEach(curso => {
                         const card = document.createElement('div');
                         card.className = 'curso-card';
-                        // Store all necessary data on the card
                         card.dataset.id = curso.id_curso_programado;
                         card.dataset.nombre = curso.nombre_curso;
                         card.dataset.precio = curso.precio_actual || '0.00';
@@ -106,7 +171,6 @@ document.addEventListener('DOMContentLoaded', function() {
                         card.dataset.profesor = curso.nombre_profesor;
                         card.dataset.horario = curso.horario_dias;
                         card.dataset.horas = `${formatTime(curso.hora_inicio)} - ${formatTime(curso.hora_fin)}`;
-                        // Raw data for validation
                         card.dataset.dias_semana_raw = curso.dias_semana;
                         card.dataset.fecha_inicio_raw = curso.fecha_inicio;
                         card.dataset.fecha_fin_raw = curso.fecha_fin;
@@ -153,7 +217,6 @@ document.addEventListener('DOMContentLoaded', function() {
                 horas: card.dataset.horas,
                 clienteId: mainClientId,
                 clienteNombre: mainClientName,
-                // Pass raw data for hidden fields
                 dias_semana_raw: card.dataset.dias_semana_raw,
                 fecha_inicio_raw: card.dataset.fecha_inicio_raw,
                 fecha_fin_raw: card.dataset.fecha_fin_raw,
@@ -164,7 +227,6 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     function agregarCursoAGrilla(curso) {
-        // Adaptación para modo de edición vs. nueva adición
         const precioPactado = curso.precio_pactado !== undefined ? curso.precio_pactado : curso.precio;
         const descuento = curso.descuento !== undefined ? curso.descuento : 0.00;
         const precioFinal = precioPactado - descuento;
@@ -335,20 +397,12 @@ document.addEventListener('DOMContentLoaded', function() {
     // --- Lógica para la Validación y Envío del Formulario ---
     const formMatricula = document.getElementById('form-matricula');
     formMatricula.addEventListener('submit', function(e) {
-        // 1. Validación de cruce de horarios en la grilla (lado del cliente)
         if (!validarCruceHorariosCliente()) {
-            e.preventDefault(); // Detener el envío del formulario si hay errores
+            e.preventDefault();
             return;
         }
-
-        // Si todas las validaciones del lado del cliente pasan, el formulario se enviará.
-        // Las validaciones del lado del servidor se encargarán del resto.
     });
 
-    /**
-     * Valida que un mismo cliente no tenga cursos con horarios y ubicaciones que se crucen
-     * dentro de la misma matrícula que se está creando.
-     */
     function validarCruceHorariosCliente() {
         const cursosPorCliente = {};
         const filas = document.querySelectorAll('#cursos-seleccionados-grid tbody tr');
@@ -358,7 +412,6 @@ document.addEventListener('DOMContentLoaded', function() {
             return false;
         }
 
-        // Agrupar cursos por cliente
         for (const fila of filas) {
             const clienteId = fila.querySelector('.id-cliente-asistente').value;
             const clienteNombre = fila.querySelector('.cliente-asistente-search').value;
@@ -380,7 +433,6 @@ document.addEventListener('DOMContentLoaded', function() {
             cursosPorCliente[clienteId].cursos.push(cursoInfo);
         }
 
-        // Validar cruces para cada cliente
         for (const clienteId in cursosPorCliente) {
             const dataCliente = cursosPorCliente[clienteId];
             const cursos = dataCliente.cursos;
@@ -392,27 +444,21 @@ document.addEventListener('DOMContentLoaded', function() {
                         const curso1 = cursos[i];
                         const curso2 = cursos[j];
 
-                        // Comprobar si los días se cruzan
                         const diasEnComun = curso1.dias.some(dia => curso2.dias.includes(dia));
-                        // Comprobar si las horas se cruzan
                         const horasSeCruzan = (curso1.horaInicio < curso2.horaFin) && (curso1.horaFin > curso2.horaInicio);
-                        // Comprobar si la ubicación es la misma
                         const mismaUbicacion = curso1.ubicacion === curso2.ubicacion;
 
                         if (diasEnComun && horasSeCruzan && mismaUbicacion) {
                             alert(`Error de validación:\nEl cliente "${nombreCliente}" tiene un cruce de horario.\n\n- Curso 1: ${curso1.nombreCurso}\n- Curso 2: ${curso2.nombreCurso}\n- Ubicación: ${curso1.ubicacion}\n\nPor favor, corrija la selección antes de continuar.`);
-                            return false; // Cruce encontrado
+                            return false;
                         }
                     }
                 }
             }
         }
-        return true; // No se encontraron cruces
+        return true;
     }
 
-    /**
-     * Si estamos en modo de edición, esta función carga los cursos existentes en la grilla.
-     */
     function inicializarGrillaParaEdicion() {
         if (typeof matriculaDetalles !== 'undefined' && matriculaDetalles.length > 0) {
             const formatTime = (timeString) => {
@@ -436,7 +482,6 @@ document.addEventListener('DOMContentLoaded', function() {
                     horas: `${formatTime(detalle.hora_inicio)} - ${formatTime(detalle.hora_fin)}`,
                     clienteId: detalle.id_cliente_asistencia,
                     clienteNombre: detalle.nombre_cliente_asistencia,
-                    // Pass raw data for hidden fields
                     dias_semana_raw: detalle.dias_semana,
                     fecha_inicio_raw: detalle.fecha_inicio,
                     fecha_fin_raw: detalle.fecha_fin,
@@ -447,6 +492,5 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // --- Inicialización ---
     inicializarGrillaParaEdicion();
 });

--- a/views/matriculas/nueva.php
+++ b/views/matriculas/nueva.php
@@ -1,5 +1,42 @@
 <?php require_once 'views/partials/header.php'; ?>
 
+<!-- Estilos para el Modal -->
+<style>
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+.modal-container {
+    background: white;
+    padding: 20px;
+    border-radius: 5px;
+    width: 90%;
+    max-width: 600px;
+    position: relative;
+}
+.modal-close {
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    font-size: 24px;
+    font-weight: bold;
+    cursor: pointer;
+}
+.validation-error-modal {
+    color: red;
+    font-size: 0.9em;
+    margin-top: 5px;
+}
+</style>
+
 <div class="matricula-container">
     <h1>Nueva Matrícula</h1>
     <form id="form-matricula" action="index.php?view=matriculas" method="POST">
@@ -14,10 +51,12 @@
                 <div id="cliente-search-results" class="search-results"></div>
                 <input type="hidden" id="id_cliente" name="id_cliente" required>
                 <div id="cliente-seleccionado-info" style="margin-top:10px; font-weight:bold;"></div>
+                <!-- Botón para nuevo cliente, inicialmente oculto -->
+                <button type="button" id="btn-nuevo-cliente" class="btn btn-success" style="display: none; margin-top: 10px;">Nuevo Cliente</button>
             </div>
         </div>
 
-        <!-- SECCIÓN 2: CURSOS -->
+        <!-- SECCIÓN 2: CURSOS (sin cambios) -->
         <div class="section">
             <h2>2. Selección de Cursos</h2>
             <fieldset>
@@ -42,11 +81,7 @@
                     </div>
                 </div>
             </fieldset>
-
-            <div id="cursos-disponibles-container">
-                <p>Los cursos disponibles aparecerán aquí...</p>
-            </div>
-
+            <div id="cursos-disponibles-container"><p>Los cursos disponibles aparecerán aquí...</p></div>
             <h3>Cursos Agregados a la Matrícula</h3>
             <div id="cursos-seleccionados-grid">
                 <table class="table">
@@ -63,9 +98,7 @@
                             <th>Acción</th>
                         </tr>
                     </thead>
-                    <tbody>
-                        <!-- Las filas de cursos se añadirán aquí con JS -->
-                    </tbody>
+                    <tbody></tbody>
                     <tfoot>
                         <tr>
                             <td colspan="7" class="total-row">TOTAL:</td>
@@ -77,17 +110,15 @@
             </div>
         </div>
 
-        <!-- SECCIÓN 3: PAGO -->
+        <!-- SECCIÓN 3: PAGO (sin cambios) -->
         <div class="section">
             <h2>3. Datos del Pago</h2>
             <div class="form-grid">
-                <!-- Las fechas se copian desde los filtros y se envían de forma oculta -->
                 <input type="hidden" id="fecha_inicio_matricula" name="fecha_inicio_matricula">
                 <input type="hidden" id="fecha_fin_matricula" name="fecha_fin_matricula">
                 <div class="form-group">
                     <label for="id_forma_pago">Forma de Pago:</label>
                     <select id="id_forma_pago" name="id_forma_pago" required>
-                        <!-- Opciones cargadas desde BD -->
                         <option value="1">Efectivo</option>
                         <option value="2">Tarjeta de Crédito/Débito</option>
                     </select>
@@ -106,24 +137,64 @@
     </form>
 </div>
 
-<style>
-.form-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 15px;
-    margin-top: 20px;
-}
-.form-actions .btn {
-    padding: 10px 20px;
-    font-size: 1em;
-}
-</style>
+<!-- Modal para Nuevo Cliente -->
+<div id="modal-nuevo-cliente" class="modal-overlay">
+    <div class="modal-container">
+        <span id="modal-close-btn" class="modal-close">&times;</span>
+        <h2>Crear Nuevo Cliente</h2>
+        <div id="modal-error-message" class="info-message error-message" style="display: none;"></div>
+        <form id="form-nuevo-cliente">
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="modal_nombres">Nombres:</label>
+                    <input type="text" id="modal_nombres" name="nombres" required>
+                </div>
+                <div class="form-group">
+                    <label for="modal_apellidos">Apellidos:</label>
+                    <input type="text" id="modal_apellidos" name="apellidos" required>
+                </div>
+            </div>
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="modal_id_tipo_documento">Tipo de Documento:</label>
+                    <select id="modal_id_tipo_documento" name="id_tipo_documento" required>
+                        <option value="">Seleccione...</option>
+                        <?php foreach ($tipos_documento as $tipo): ?>
+                            <option value="<?php echo $tipo['id_tipo_documento']; ?>"><?php echo htmlspecialchars($tipo['descripcion']); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="modal_numero_documento">Número de Documento:</label>
+                    <input type="text" id="modal_numero_documento" name="numero_documento" required>
+                    <div id="modal-documento-error" class="validation-error-modal" style="display: none;"></div>
+                </div>
+            </div>
+            <div class="form-row">
+                 <div class="form-group">
+                    <label for="modal_email">Email:</label>
+                    <input type="email" id="modal_email" name="email">
+                </div>
+                <div class="form-group">
+                    <label for="modal_telefono">Teléfono:</label>
+                    <input type="text" id="modal_telefono" name="telefono">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="modal_codigo_erp">Código ERP:</label>
+                <input type="text" id="modal_codigo_erp" name="codigo_erp">
+            </div>
+            <div class="form-actions">
+                <button type="button" id="modal-cancel-btn" class="btn btn-secondary">Cancelar</button>
+                <button type="submit" class="btn btn-primary">Crear Cliente</button>
+            </div>
+        </form>
+    </div>
+</div>
 
 <script>
-    // Definir la variable global para que el script no falle en esta página
     const matriculaDetalles = [];
 </script>
-
 <script src="<?php echo $base_url; ?>public/assets/js/matricula_form.js"></script>
 
 <?php require_once 'views/partials/footer.php'; ?>


### PR DESCRIPTION
This commit introduces a new feature to streamline the new enrollment process. Users can now create a new client directly from the 'Nueva Matrícula' page without navigating away.

- A 'Nuevo Cliente' button now appears on the enrollment page if a client search yields no results.
- Clicking the button opens a modal dialog containing a form to create a new client.
- A new AJAX endpoint (`crear_ajax`) has been added to the `clientes_controller` to handle the form submission from the modal. This endpoint creates the client and returns its data as a JSON response.
- The JavaScript on the enrollment page has been updated to manage the modal and handle the AJAX response, automatically populating the main form with the new client's information upon successful creation.