### PR TITLE
fix(matricula): Improve error handling in new client modal

### DIFF
--- a/models/ClienteModel.php
+++ b/models/ClienteModel.php
@@ -48,10 +48,17 @@ class ClienteModel {
             $result = $this->db->single();
             return ['success' => true, 'id' => $result['id_cliente'] ?? 0];
         } catch (PDOException $e) {
+            // Log the detailed error for the developer
+            error_log("PDOException in ClienteModel::crear: " . $e->getMessage());
+
+            // Check if it's a user-defined exception (like duplicate document)
             if ($e->getCode() == '45000') {
+                // Return the specific message from the stored procedure
                 return ['success' => false, 'error' => $e->errorInfo[2]];
+            } else {
+                // Return a generic error for other database issues
+                return ['success' => false, 'error' => 'Ocurrió un error en la base de datos al crear el cliente.'];
             }
-            throw $e;
         }
     }
 


### PR DESCRIPTION
This commit fixes a bug in the inline client creation modal where a generic 'Connection Error' was shown for server-side validation failures.

The `crear` method in `ClienteModel` has been updated to properly catch all PDOExceptions. It now returns a structured JSON error response instead of letting the exception go uncaught.

This ensures that specific validation messages from the database (e.g., 'El número de documento ya está en uso') are correctly passed to the frontend and displayed to the user in the modal, improving the user experience.