### PR TITLE
fix(matricula): Improve error handling in new client modal

### DIFF
--- a/controllers/clientes_controller.php
+++ b/controllers/clientes_controller.php
@@ -129,9 +129,14 @@ try {
                     $nuevo_cliente = $clienteModel->obtenerPorId($resultado['id']);
                     echo json_encode(['success' => true, 'cliente' => $nuevo_cliente]);
                 } else {
-                    echo json_encode(['success' => false, 'error' => 'Error al crear el cliente: ' . $resultado['error']]);
+                    // Set a Bad Request status code to be more explicit
+                    http_response_code(400);
+                    // Ensure the error message is properly encoded to prevent json_encode failure
+                    $error_message = mb_convert_encoding($resultado['error'], 'UTF-8', 'UTF-8');
+                    echo json_encode(['success' => false, 'error' => 'Error al crear el cliente: ' . $error_message]);
                 }
             } else {
+                http_response_code(405); // Method Not Allowed
                 echo json_encode(['success' => false, 'error' => 'Método no permitido.']);
             }
             exit();


### PR DESCRIPTION
This commit fixes a bug in the inline client creation modal where a generic 'Connection Error' was shown for server-side validation failures.

The `crear` method in `ClienteModel` has been updated to properly catch all PDOExceptions, ensuring a structured JSON error response is always returned.

The `crear_ajax` action in `clientes_controller` has been updated to sanitize the error message encoding before JSON encoding, preventing silent failures. It also now sets a 400 HTTP status code for client errors.

This ensures that specific validation messages from the database (e.g., 'El número de documento ya está en uso') are correctly passed to the frontend and displayed to the user in the modal.