### PR TITLE
feat(clientes): Add address and ubigeo fields to clients

### DIFF
--- a/bd/update_v1.33_add_client_address.sql
+++ b/bd/update_v1.33_add_client_address.sql
@@ -1,0 +1,133 @@
+-- =================================================================
+-- Script de Actualización de la Base de Datos - Versión 1.33
+-- Añade campos de dirección y ubigeo a los clientes.
+-- Modifica `apellidos` para que sea opcional (para RUC).
+-- =================================================================
+
+USE `academia_cursos`;
+
+-- 1. Modificar la tabla de clientes
+ALTER TABLE `clientes`
+ADD COLUMN `direccion` VARCHAR(255) NULL AFTER `codigo_erp`,
+ADD COLUMN `codigo_ubigeo` VARCHAR(10) NULL AFTER `direccion`,
+MODIFY COLUMN `apellidos` VARCHAR(100) NULL; -- Hacer apellidos opcional
+
+-- 2. Actualizar los procedimientos almacenados
+
+DELIMITER $$
+
+-- -----------------------------------------------------
+-- `sp_clientes_listar`
+-- -----------------------------------------------------
+DROP PROCEDURE IF EXISTS `sp_clientes_listar`$$
+CREATE PROCEDURE `sp_clientes_listar`()
+BEGIN
+    SELECT
+        c.id_cliente,
+        c.nombres,
+        c.apellidos,
+        td.descripcion AS tipo_documento,
+        c.numero_documento,
+        c.email,
+        c.telefono,
+        c.direccion,
+        c.codigo_ubigeo
+    FROM clientes c
+    JOIN tipos_documento td ON c.id_tipo_documento = td.id_tipo_documento
+    ORDER BY c.apellidos, c.nombres;
+END$$
+
+-- -----------------------------------------------------
+-- `sp_clientes_obtener_por_id`
+-- -----------------------------------------------------
+DROP PROCEDURE IF EXISTS `sp_clientes_obtener_por_id`$$
+CREATE PROCEDURE `sp_clientes_obtener_por_id`(IN p_id_cliente INT)
+BEGIN
+    SELECT
+        id_cliente,
+        id_tipo_documento,
+        numero_documento,
+        nombres,
+        apellidos,
+        email,
+        telefono,
+        codigo_erp,
+        direccion,
+        codigo_ubigeo
+    FROM clientes
+    WHERE id_cliente = p_id_cliente;
+END$$
+
+-- -----------------------------------------------------
+-- `sp_clientes_crear`
+-- -----------------------------------------------------
+DROP PROCEDURE IF EXISTS `sp_clientes_crear`$$
+CREATE PROCEDURE `sp_clientes_crear`(
+    IN p_id_tipo_documento INT,
+    IN p_numero_documento VARCHAR(20),
+    IN p_nombres VARCHAR(100),
+    IN p_apellidos VARCHAR(100),
+    IN p_email VARCHAR(100),
+    IN p_telefono VARCHAR(20),
+    IN p_codigo_erp VARCHAR(20),
+    IN p_direccion VARCHAR(255),
+    IN p_codigo_ubigeo VARCHAR(10)
+)
+BEGIN
+    DECLARE cliente_existente INT;
+
+    SELECT COUNT(*) INTO cliente_existente
+    FROM clientes
+    WHERE id_tipo_documento = p_id_tipo_documento AND numero_documento = p_numero_documento;
+
+    IF cliente_existente > 0 THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Ya existe un cliente con el mismo tipo y número de documento.';
+    ELSE
+        INSERT INTO clientes (id_tipo_documento, numero_documento, nombres, apellidos, email, telefono, codigo_erp, direccion, codigo_ubigeo)
+        VALUES (p_id_tipo_documento, p_numero_documento, p_nombres, p_apellidos, p_email, p_telefono, p_codigo_erp, p_direccion, p_codigo_ubigeo);
+        SELECT LAST_INSERT_ID() as id_cliente;
+    END IF;
+END$$
+
+-- -----------------------------------------------------
+-- `sp_clientes_actualizar`
+-- -----------------------------------------------------
+DROP PROCEDURE IF EXISTS `sp_clientes_actualizar`$$
+CREATE PROCEDURE `sp_clientes_actualizar`(
+    IN p_id_cliente INT,
+    IN p_id_tipo_documento INT,
+    IN p_numero_documento VARCHAR(20),
+    IN p_nombres VARCHAR(100),
+    IN p_apellidos VARCHAR(100),
+    IN p_email VARCHAR(100),
+    IN p_telefono VARCHAR(20),
+    IN p_codigo_erp VARCHAR(20),
+    IN p_direccion VARCHAR(255),
+    IN p_codigo_ubigeo VARCHAR(10)
+)
+BEGIN
+    DECLARE cliente_existente INT;
+    SELECT COUNT(*) INTO cliente_existente
+    FROM clientes
+    WHERE id_tipo_documento = p_id_tipo_documento
+      AND numero_documento = p_numero_documento
+      AND id_cliente != p_id_cliente;
+
+    IF cliente_existente > 0 THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'El nuevo número de documento ya está en uso por otro cliente.';
+    ELSE
+        UPDATE clientes SET
+            id_tipo_documento = p_id_tipo_documento,
+            numero_documento = p_numero_documento,
+            nombres = p_nombres,
+            apellidos = p_apellidos,
+            email = p_email,
+            telefono = p_telefono,
+            codigo_erp = p_codigo_erp,
+            direccion = p_direccion,
+            codigo_ubigeo = p_codigo_ubigeo
+        WHERE id_cliente = p_id_cliente;
+    END IF;
+END$$
+
+DELIMITER ;

--- a/controllers/clientes_controller.php
+++ b/controllers/clientes_controller.php
@@ -40,7 +40,9 @@ try {
                     'apellidos' => $_POST['apellidos'],
                     'email' => $_POST['email'],
                     'telefono' => $_POST['telefono'],
-                    'codigo_erp' => $_POST['codigo_erp']
+                    'codigo_erp' => $_POST['codigo_erp'],
+                    'direccion' => $_POST['direccion'],
+                    'codigo_ubigeo' => $_POST['codigo_ubigeo']
                 ];
                 $resultado = $clienteModel->crear($datos);
                 if ($resultado['success']) {
@@ -65,7 +67,9 @@ try {
                     'apellidos' => $_POST['apellidos'],
                     'email' => $_POST['email'],
                     'telefono' => $_POST['telefono'],
-                    'codigo_erp' => $_POST['codigo_erp']
+                    'codigo_erp' => $_POST['codigo_erp'],
+                    'direccion' => $_POST['direccion'],
+                    'codigo_ubigeo' => $_POST['codigo_ubigeo']
                 ];
                 $resultado = $clienteModel->actualizar($datos);
 
@@ -107,10 +111,12 @@ try {
                     'apellidos' => $_POST['apellidos'],
                     'email' => $_POST['email'] ?? null,
                     'telefono' => $_POST['telefono'] ?? null,
-                    'codigo_erp' => $_POST['codigo_erp'] ?? null
+                    'codigo_erp' => $_POST['codigo_erp'] ?? null,
+                    'direccion' => $_POST['direccion'] ?? null,
+                    'codigo_ubigeo' => $_POST['codigo_ubigeo'] ?? null
                 ];
 
-                if (empty($datos['nombres']) || empty($datos['apellidos']) || empty($datos['numero_documento'])) {
+                if (empty($datos['nombres']) || empty($datos['numero_documento'])) {
                     http_response_code(400);
                     echo json_encode(['success' => false, 'error' => 'Nombres, apellidos y número de documento son obligatorios.']);
                     exit();

--- a/models/ClienteModel.php
+++ b/models/ClienteModel.php
@@ -41,7 +41,9 @@ class ClienteModel {
             $datos['apellidos'],
             $datos['email'],
             $datos['telefono'],
-            $datos['codigo_erp']
+            $datos['codigo_erp'],
+            $datos['direccion'],
+            $datos['codigo_ubigeo']
         ];
         try {
             $this->db->callStoredProcedure('sp_clientes_crear', $params);
@@ -76,7 +78,9 @@ class ClienteModel {
             $datos['apellidos'],
             $datos['email'],
             $datos['telefono'],
-            $datos['codigo_erp']
+            $datos['codigo_erp'],
+            $datos['direccion'],
+            $datos['codigo_ubigeo']
         ];
         try {
             $this->db->callStoredProcedure('sp_clientes_actualizar', $params);

--- a/views/clientes/form.php
+++ b/views/clientes/form.php
@@ -69,6 +69,17 @@ $action_url = $is_edit ? 'index.php?view=clientes&action=update' : 'index.php?vi
             <input type="text" id="codigo_erp" name="codigo_erp" value="<?php echo htmlspecialchars($cliente_a_editar['codigo_erp'] ?? ''); ?>">
         </div>
 
+        <div class="form-row">
+            <div class="form-group">
+                <label for="direccion">Dirección:</label>
+                <input type="text" id="direccion" name="direccion" value="<?php echo htmlspecialchars($cliente_a_editar['direccion'] ?? ''); ?>">
+            </div>
+            <div class="form-group">
+                <label for="codigo_ubigeo">Código de Ubigeo:</label>
+                <input type="text" id="codigo_ubigeo" name="codigo_ubigeo" value="<?php echo htmlspecialchars($cliente_a_editar['codigo_ubigeo'] ?? ''); ?>">
+            </div>
+        </div>
+
         <div class="form-actions">
             <a href="index.php?view=clientes" class="btn btn-secondary">Cancelar</a>
             <button type="submit" id="submit-btn" class="btn btn-primary"><?php echo $is_edit ? 'Actualizar Cliente' : 'Crear Cliente'; ?></button>

--- a/views/clientes/list.php
+++ b/views/clientes/list.php
@@ -32,13 +32,15 @@
             <th>Documento</th>
             <th>Email</th>
             <th>Teléfono</th>
+            <th>Dirección</th>
+            <th>Ubigeo</th>
             <th>Acciones</th>
         </tr>
     </thead>
     <tbody>
         <?php if (empty($clientes)): ?>
             <tr>
-                <td colspan="6">No se encontraron clientes.</td>
+                <td colspan="9">No se encontraron clientes.</td>
             </tr>
         <?php else: ?>
             <?php foreach ($clientes as $cliente): ?>
@@ -48,6 +50,8 @@
                     <td><?php echo htmlspecialchars($cliente['tipo_documento']) . ': ' . htmlspecialchars($cliente['numero_documento']); ?></td>
                     <td><?php echo htmlspecialchars($cliente['email']); ?></td>
                     <td><?php echo htmlspecialchars($cliente['telefono']); ?></td>
+                    <td><?php echo htmlspecialchars($cliente['direccion'] ?? ''); ?></td>
+                    <td><?php echo htmlspecialchars($cliente['codigo_ubigeo'] ?? ''); ?></td>
                     <td>
                         <a href="index.php?view=clientes&action=edit&id=<?php echo $cliente['id_cliente']; ?>" class="btn btn-warning">Editar</a>
                         <a href="index.php?view=clientes&action=delete&id=<?php echo $cliente['id_cliente']; ?>" class="btn btn-danger" onclick="return confirm('¿Está seguro de que desea eliminar este cliente?');">Eliminar</a>

--- a/views/matriculas/nueva.php
+++ b/views/matriculas/nueva.php
@@ -183,6 +183,16 @@
                 <label for="modal_codigo_erp">Código ERP:</label>
                 <input type="text" id="modal_codigo_erp" name="codigo_erp">
             </div>
+        <div class="form-row">
+            <div class="form-group">
+                <label for="modal_direccion">Dirección:</label>
+                <input type="text" id="modal_direccion" name="direccion">
+            </div>
+            <div class="form-group">
+                <label for="modal_codigo_ubigeo">Código de Ubigeo:</label>
+                <input type="text" id="modal_codigo_ubigeo" name="codigo_ubigeo">
+            </div>
+        </div>
             <div class="form-actions">
                 <button type="button" id="modal-cancel-btn" class="btn btn-secondary">Cancelar</button>
                 <button type="submit" class="btn btn-primary">Crear Cliente</button>


### PR DESCRIPTION
This commit adds 'Dirección' (Address) and 'Código de Ubigeo' (Geographic Location Code) fields to the client entity.

This is a full-stack change that includes:
- A new database migration script to alter the `clientes` table and update the relevant stored procedures (`sp_clientes_crear`, `sp_clientes_actualizar`, `sp_clientes_listar`, `sp_clientes_obtener_por_id`).
- The `apellidos` column was also made nullable to support RUC document types where it is not required.
- The `ClienteModel` and `clientes_controller` have been updated to handle the new data fields in all create and update operations, including the AJAX endpoint for the enrollment modal.
- The client management views (`list.php`, `form.php`) and the new client modal in the enrollment page (`nueva.php`) have been updated to include input fields for the new data.