### PR TITLE
refactor(clientes): Apply dynamic RUC logic to main client form

### DIFF
--- a/public/assets/js/cliente_form.js
+++ b/public/assets/js/cliente_form.js
@@ -1,0 +1,89 @@
+// =================================================================
+// Lógica JavaScript para el formulario de Clientes (form.php)
+// =================================================================
+document.addEventListener('DOMContentLoaded', function() {
+
+    // --- Referencias a elementos del Formulario ---
+    const tipoDocumentoSelect = document.getElementById('id_tipo_documento');
+    const labelNombres = document.getElementById('label_nombres');
+    const groupApellidos = document.getElementById('group_apellidos');
+    const inputDocumento = document.getElementById('numero_documento');
+    const documentoError = document.getElementById('documento-error');
+    const submitBtn = document.getElementById('submit-btn');
+    const idClienteInput = document.getElementById('id_cliente'); // Existe solo en modo edición
+    let debounceTimeout;
+
+    // --- Función para manejar la lógica de RUC ---
+    function handleRucLogic() {
+        if (!tipoDocumentoSelect) return;
+
+        const selectedOptionText = tipoDocumentoSelect.options[tipoDocumentoSelect.selectedIndex].text.trim().toUpperCase();
+
+        if (selectedOptionText === 'RUC') {
+            if(labelNombres) labelNombres.textContent = 'Razón Social:';
+            if(groupApellidos) groupApellidos.style.display = 'none';
+        } else {
+            if(labelNombres) labelNombres.textContent = 'Nombres:';
+            if(groupApellidos) groupApellidos.style.display = 'block';
+        }
+    }
+
+    // --- Event Listener para el cambio de tipo de documento ---
+    if (tipoDocumentoSelect) {
+        tipoDocumentoSelect.addEventListener('change', handleRucLogic);
+        // Llamar una vez al cargar la página para establecer el estado inicial (importante para modo edición)
+        handleRucLogic();
+    }
+
+    // --- Event Listener para la validación de documento duplicado ---
+    // --- Lógica de validación en el envío del formulario ---
+    const clienteForm = document.getElementById('cliente-form');
+    if(clienteForm) {
+        clienteForm.addEventListener('submit', function(e) {
+            // Validar apellidos solo si es requerido
+            const selectedOptionText = tipoDocumentoSelect.options[tipoDocumentoSelect.selectedIndex].text.trim().toUpperCase();
+            const apellidosInput = document.getElementById('apellidos');
+
+            if (selectedOptionText !== 'RUC' && apellidosInput.value.trim() === '') {
+                e.preventDefault(); // Detener el envío
+                // Re-usar el div de error de documento para este mensaje o crear uno nuevo
+                documentoError.textContent = 'El campo Apellidos es obligatorio para este tipo de documento.';
+                documentoError.style.display = 'block';
+            }
+        });
+    }
+
+    if (inputDocumento) {
+        inputDocumento.addEventListener('keyup', function() {
+            clearTimeout(debounceTimeout);
+            const numeroDocumento = this.value;
+            const idCliente = idClienteInput ? idClienteInput.value : null;
+
+            if (numeroDocumento.length < 3) {
+                return;
+            }
+
+            debounceTimeout = setTimeout(() => {
+                let url = `index.php?view=clientes&action=check_documento&numero_documento=${encodeURIComponent(numeroDocumento)}`;
+                if (idCliente) {
+                    url += `&id_cliente=${idCliente}`;
+                }
+
+                fetch(url)
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.exists) {
+                            documentoError.textContent = 'Este número de documento ya está registrado.';
+                            documentoError.style.display = 'block';
+                            submitBtn.disabled = true;
+                        } else {
+                            documentoError.style.display = 'none';
+                            submitBtn.disabled = false;
+                        }
+                    })
+                    .catch(error => console.error('Error al verificar documento:', error));
+            }, 500);
+        });
+    }
+
+});

--- a/views/clientes/form.php
+++ b/views/clientes/form.php
@@ -25,17 +25,6 @@ $action_url = $is_edit ? 'index.php?view=clientes&action=update' : 'index.php?vi
 
         <div class="form-row">
             <div class="form-group">
-                <label for="nombres">Nombres:</label>
-                <input type="text" id="nombres" name="nombres" value="<?php echo htmlspecialchars($cliente_a_editar['nombres'] ?? ''); ?>" required>
-            </div>
-            <div class="form-group">
-                <label for="apellidos">Apellidos:</label>
-                <input type="text" id="apellidos" name="apellidos" value="<?php echo htmlspecialchars($cliente_a_editar['apellidos'] ?? ''); ?>" required>
-            </div>
-        </div>
-
-        <div class="form-row">
-            <div class="form-group">
                 <label for="id_tipo_documento">Tipo de Documento:</label>
                 <select id="id_tipo_documento" name="id_tipo_documento" required>
                     <option value="">Seleccione...</option>
@@ -55,6 +44,17 @@ $action_url = $is_edit ? 'index.php?view=clientes&action=update' : 'index.php?vi
         </div>
 
         <div class="form-row">
+            <div class="form-group">
+                <label for="nombres" id="label_nombres">Nombres:</label>
+                <input type="text" id="nombres" name="nombres" value="<?php echo htmlspecialchars($cliente_a_editar['nombres'] ?? ''); ?>" required>
+            </div>
+            <div class="form-group" id="group_apellidos">
+                <label for="apellidos">Apellidos:</label>
+                <input type="text" id="apellidos" name="apellidos" value="<?php echo htmlspecialchars($cliente_a_editar['apellidos'] ?? ''); ?>">
+            </div>
+        </div>
+
+        <div class="form-row">
              <div class="form-group">
                 <label for="email">Email:</label>
                 <input type="email" id="email" name="email" value="<?php echo htmlspecialchars($cliente_a_editar['email'] ?? ''); ?>">
@@ -63,10 +63,6 @@ $action_url = $is_edit ? 'index.php?view=clientes&action=update' : 'index.php?vi
                 <label for="telefono">Teléfono:</label>
                 <input type="text" id="telefono" name="telefono" value="<?php echo htmlspecialchars($cliente_a_editar['telefono'] ?? ''); ?>">
             </div>
-        </div>
-        <div class="form-group">
-            <label for="codigo_erp">Código ERP:</label>
-            <input type="text" id="codigo_erp" name="codigo_erp" value="<?php echo htmlspecialchars($cliente_a_editar['codigo_erp'] ?? ''); ?>">
         </div>
 
         <div class="form-row">
@@ -80,11 +76,19 @@ $action_url = $is_edit ? 'index.php?view=clientes&action=update' : 'index.php?vi
             </div>
         </div>
 
+        <div class="form-group">
+            <label for="codigo_erp">Código ERP:</label>
+            <input type="text" id="codigo_erp" name="codigo_erp" value="<?php echo htmlspecialchars($cliente_a_editar['codigo_erp'] ?? ''); ?>">
+        </div>
+
         <div class="form-actions">
             <a href="index.php?view=clientes" class="btn btn-secondary">Cancelar</a>
             <button type="submit" id="submit-btn" class="btn btn-primary"><?php echo $is_edit ? 'Actualizar Cliente' : 'Crear Cliente'; ?></button>
         </div>
     </form>
 </div>
+
+<!-- Incluir el nuevo archivo JS -->
+<script src="public/assets/js/cliente_form.js"></script>
 
 <?php require_once 'views/partials/footer.php'; ?>


### PR DESCRIPTION
This commit refactors the main client creation and editing form (`views/clientes/form.php`) to mirror the dynamic functionality of the new client modal.

- The form fields have been reordered to a more logical layout.
- A new dedicated JavaScript file (`public/assets/js/cliente_form.js`) has been created to handle the form's logic.
- The form now dynamically changes based on the selected document type. For 'RUC', the 'Nombres' label becomes 'Razón Social' and the 'Apellidos' field is hidden.
- Real-time, client-side validation has been added to check for duplicate document numbers as the user types, providing immediate feedback.
- The 'Apellidos' field is now conditionally required via JavaScript, only when the document type is not 'RUC'.