### PR TITLE
refactor(clientes): Reorder fields in client forms

### DIFF
--- a/views/clientes/form.php
+++ b/views/clientes/form.php
@@ -55,17 +55,6 @@ $action_url = $is_edit ? 'index.php?view=clientes&action=update' : 'index.php?vi
         </div>
 
         <div class="form-row">
-             <div class="form-group">
-                <label for="email">Email:</label>
-                <input type="email" id="email" name="email" value="<?php echo htmlspecialchars($cliente_a_editar['email'] ?? ''); ?>">
-            </div>
-            <div class="form-group">
-                <label for="telefono">Teléfono:</label>
-                <input type="text" id="telefono" name="telefono" value="<?php echo htmlspecialchars($cliente_a_editar['telefono'] ?? ''); ?>">
-            </div>
-        </div>
-
-        <div class="form-row">
             <div class="form-group">
                 <label for="direccion">Dirección:</label>
                 <input type="text" id="direccion" name="direccion" value="<?php echo htmlspecialchars($cliente_a_editar['direccion'] ?? ''); ?>">
@@ -73,6 +62,17 @@ $action_url = $is_edit ? 'index.php?view=clientes&action=update' : 'index.php?vi
             <div class="form-group">
                 <label for="codigo_ubigeo">Código de Ubigeo:</label>
                 <input type="text" id="codigo_ubigeo" name="codigo_ubigeo" value="<?php echo htmlspecialchars($cliente_a_editar['codigo_ubigeo'] ?? ''); ?>">
+            </div>
+        </div>
+
+        <div class="form-row">
+             <div class="form-group">
+                <label for="email">Email:</label>
+                <input type="email" id="email" name="email" value="<?php echo htmlspecialchars($cliente_a_editar['email'] ?? ''); ?>">
+            </div>
+            <div class="form-group">
+                <label for="telefono">Teléfono:</label>
+                <input type="text" id="telefono" name="telefono" value="<?php echo htmlspecialchars($cliente_a_editar['telefono'] ?? ''); ?>">
             </div>
         </div>
 

--- a/views/matriculas/nueva.php
+++ b/views/matriculas/nueva.php
@@ -166,7 +166,17 @@
                 </div>
                 <div class="form-group" id="group_modal_apellidos">
                     <label for="modal_apellidos">Apellidos:</label>
-                    <input type="text" id="modal_apellidos" name="apellidos"> <!-- `required` eliminado -->
+                    <input type="text" id="modal_apellidos" name="apellidos">
+                </div>
+            </div>
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="modal_direccion">Dirección:</label>
+                    <input type="text" id="modal_direccion" name="direccion">
+                </div>
+                <div class="form-group">
+                    <label for="modal_codigo_ubigeo">Código de Ubigeo:</label>
+                    <input type="text" id="modal_codigo_ubigeo" name="codigo_ubigeo">
                 </div>
             </div>
             <div class="form-row">
@@ -183,16 +193,6 @@
                 <label for="modal_codigo_erp">Código ERP:</label>
                 <input type="text" id="modal_codigo_erp" name="codigo_erp">
             </div>
-        <div class="form-row">
-            <div class="form-group">
-                <label for="modal_direccion">Dirección:</label>
-                <input type="text" id="modal_direccion" name="direccion">
-            </div>
-            <div class="form-group">
-                <label for="modal_codigo_ubigeo">Código de Ubigeo:</label>
-                <input type="text" id="modal_codigo_ubigeo" name="codigo_ubigeo">
-            </div>
-        </div>
             <div class="form-actions">
                 <button type="button" id="modal-cancel-btn" class="btn btn-secondary">Cancelar</button>
                 <button type="submit" class="btn btn-primary">Crear Cliente</button>


### PR DESCRIPTION
This commit reorders the input fields in the client creation forms to match the user's specified layout.

The new order is:
1. Tipo de Documento
2. Número de Documento
3. Nombres / Razón Social
4. Apellidos
5. Dirección
6. Código de Ubigeo
7. Email
8. Teléfono
9. Código ERP

This change has been applied to both the main client form (`views/clientes/form.php`) and the new client modal on the enrollment page (`views/matriculas/nueva.php`) to ensure a consistent user experience.