### PR TITLE
feat(clientes): Add Sunat API integration to client forms

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -479,3 +479,13 @@ footer {
     padding-top: 20px;
     margin-top: 20px;
 }
+
+.input-with-button {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+
+.input-with-button input {
+    flex-grow: 1;
+}

--- a/public/assets/js/cliente_form.js
+++ b/public/assets/js/cliente_form.js
@@ -10,10 +10,15 @@ document.addEventListener('DOMContentLoaded', function() {
     const inputDocumento = document.getElementById('numero_documento');
     const documentoError = document.getElementById('documento-error');
     const submitBtn = document.getElementById('submit-btn');
-    const idClienteInput = document.getElementById('id_cliente'); // Existe solo en modo edición
+    const idClienteInput = document.getElementById('id_cliente');
+    const btnSunat = document.getElementById('btn_sunat');
+    const inputNombres = document.getElementById('nombres');
+    const inputApellidos = document.getElementById('apellidos');
+    const inputDireccion = document.getElementById('direccion');
+    const inputUbigeo = document.getElementById('codigo_ubigeo');
     let debounceTimeout;
 
-    // --- Función para manejar la lógica de RUC ---
+    // --- Función para manejar la lógica de RUC y visibilidad del botón Sunat ---
     function handleRucLogic() {
         if (!tipoDocumentoSelect) return;
 
@@ -22,35 +27,22 @@ document.addEventListener('DOMContentLoaded', function() {
         if (selectedOptionText === 'RUC') {
             if(labelNombres) labelNombres.textContent = 'Razón Social:';
             if(groupApellidos) groupApellidos.style.display = 'none';
+            if(btnSunat) btnSunat.style.display = 'inline-block';
+        } else if (selectedOptionText === 'DNI') {
+            if(labelNombres) labelNombres.textContent = 'Nombres:';
+            if(groupApellidos) groupApellidos.style.display = 'block';
+            if(btnSunat) btnSunat.style.display = 'inline-block';
         } else {
             if(labelNombres) labelNombres.textContent = 'Nombres:';
             if(groupApellidos) groupApellidos.style.display = 'block';
+            if(btnSunat) btnSunat.style.display = 'none';
         }
     }
 
-    // --- Event Listener para el cambio de tipo de documento ---
+    // --- Event Listeners ---
     if (tipoDocumentoSelect) {
         tipoDocumentoSelect.addEventListener('change', handleRucLogic);
-        // Llamar una vez al cargar la página para establecer el estado inicial (importante para modo edición)
-        handleRucLogic();
-    }
-
-    // --- Event Listener para la validación de documento duplicado ---
-    // --- Lógica de validación en el envío del formulario ---
-    const clienteForm = document.getElementById('cliente-form');
-    if(clienteForm) {
-        clienteForm.addEventListener('submit', function(e) {
-            // Validar apellidos solo si es requerido
-            const selectedOptionText = tipoDocumentoSelect.options[tipoDocumentoSelect.selectedIndex].text.trim().toUpperCase();
-            const apellidosInput = document.getElementById('apellidos');
-
-            if (selectedOptionText !== 'RUC' && apellidosInput.value.trim() === '') {
-                e.preventDefault(); // Detener el envío
-                // Re-usar el div de error de documento para este mensaje o crear uno nuevo
-                documentoError.textContent = 'El campo Apellidos es obligatorio para este tipo de documento.';
-                documentoError.style.display = 'block';
-            }
-        });
+        handleRucLogic(); // Estado inicial
     }
 
     if (inputDocumento) {
@@ -59,15 +51,11 @@ document.addEventListener('DOMContentLoaded', function() {
             const numeroDocumento = this.value;
             const idCliente = idClienteInput ? idClienteInput.value : null;
 
-            if (numeroDocumento.length < 3) {
-                return;
-            }
+            if (numeroDocumento.length < 3) return;
 
             debounceTimeout = setTimeout(() => {
                 let url = `index.php?view=clientes&action=check_documento&numero_documento=${encodeURIComponent(numeroDocumento)}`;
-                if (idCliente) {
-                    url += `&id_cliente=${idCliente}`;
-                }
+                if (idCliente) url += `&id_cliente=${idCliente}`;
 
                 fetch(url)
                     .then(response => response.json())
@@ -86,4 +74,66 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
+    if (btnSunat) {
+        btnSunat.addEventListener('click', function() {
+            const numero = inputDocumento.value.trim();
+            const tipoDocText = tipoDocumentoSelect.options[tipoDocumentoSelect.selectedIndex].text.trim().toUpperCase();
+
+            if ((tipoDocText === 'DNI' && numero.length !== 8) || (tipoDocText === 'RUC' && numero.length !== 11)) {
+                alert(`El número de ${tipoDocText} debe tener ${tipoDocText === 'DNI' ? 8 : 11} dígitos.`);
+                return;
+            }
+
+            let apiUrl = '';
+            if (tipoDocText === 'DNI') {
+                apiUrl = `https://api.apis.net.pe/v1/dni?numero=${numero}`;
+            } else if (tipoDocText === 'RUC') {
+                apiUrl = `https://api.apis.net.pe/v1/ruc?numero=${numero}`;
+            } else {
+                return; // No hacer nada si no es DNI o RUC
+            }
+
+            this.textContent = '...';
+            this.disabled = true;
+
+            fetch(apiUrl)
+                .then(response => response.json())
+                .then(data => {
+                    if (data.numeroDocumento) {
+                        if (tipoDocText === 'DNI') {
+                            inputNombres.value = data.nombres || '';
+                            inputApellidos.value = `${data.apellidoPaterno || ''} ${data.apellidoMaterno || ''}`.trim();
+                        } else if (tipoDocText === 'RUC') {
+                            inputNombres.value = data.nombre || '';
+                            inputDireccion.value = data.direccion || '';
+                            inputUbigeo.value = data.ubigeo || '';
+                        }
+                    } else {
+                        alert('No se encontraron datos para el documento ingresado.');
+                    }
+                })
+                .catch(error => {
+                    console.error('Error en la consulta a la API:', error);
+                    alert('Ocurrió un error al consultar el servicio.');
+                })
+                .finally(() => {
+                    this.textContent = 'Sunat';
+                    this.disabled = false;
+                });
+        });
+    }
+
+    const clienteForm = document.getElementById('cliente-form');
+    if(clienteForm) {
+        clienteForm.addEventListener('submit', function(e) {
+            const selectedOptionText = tipoDocumentoSelect.options[tipoDocumentoSelect.selectedIndex].text.trim().toUpperCase();
+            const apellidosInput = document.getElementById('apellidos');
+
+            if (selectedOptionText !== 'RUC' && apellidosInput.value.trim() === '') {
+                e.preventDefault();
+                documentoError.textContent = 'El campo Apellidos es obligatorio para este tipo de documento.';
+                documentoError.style.display = 'block';
+            }
+        });
+    }
 });

--- a/public/assets/js/matricula_form.js
+++ b/public/assets/js/matricula_form.js
@@ -1,5 +1,5 @@
 // =================================================================
-// Lógica JavaScript para la página de Nueva Matrícula (v5 con validación de apellidos)
+// Lógica JavaScript para la página de Nueva Matrícula (v6 con API Sunat)
 // =================================================================
 document.addEventListener('DOMContentLoaded', function() {
 
@@ -17,6 +17,10 @@ document.addEventListener('DOMContentLoaded', function() {
     const modalLabelNombres = document.getElementById('label_modal_nombres');
     const modalGroupApellidos = document.getElementById('group_modal_apellidos');
     const modalInputApellidos = document.getElementById('modal_apellidos');
+    const modalBtnSunat = document.getElementById('btn_sunat_modal');
+    const modalInputNombres = document.getElementById('modal_nombres');
+    const modalInputDireccion = document.getElementById('modal_direccion');
+    const modalInputUbigeo = document.getElementById('modal_codigo_ubigeo');
     let debounceTimeout;
 
 
@@ -31,9 +35,7 @@ document.addEventListener('DOMContentLoaded', function() {
         clearTimeout(mainClientSearchTimeout);
         const query = this.value;
         btnNuevoCliente.style.display = 'none';
-
         if (query.length < 2) { resultsContainer.innerHTML = ''; return; }
-
         mainClientSearchTimeout = setTimeout(() => {
             fetch(`index.php?view=matriculas&action=buscar_cliente&q=${encodeURIComponent(query)}`)
                 .then(response => response.json())
@@ -86,20 +88,76 @@ document.addEventListener('DOMContentLoaded', function() {
         modalSubmitBtn.disabled = false;
         modalLabelNombres.textContent = 'Nombres:';
         modalGroupApellidos.style.display = 'block';
+        modalBtnSunat.style.display = 'none';
     }
 
     btnCerrarModal.addEventListener('click', cerrarModal);
     btnCancelarModal.addEventListener('click', cerrarModal);
 
+    // --- Lógica Dinámica para RUC y Botón Sunat en Modal ---
     modalTipoDocumento.addEventListener('change', function() {
         const selectedOptionText = this.options[this.selectedIndex].text.trim().toUpperCase();
         if (selectedOptionText === 'RUC') {
             modalLabelNombres.textContent = 'Razón Social:';
             modalGroupApellidos.style.display = 'none';
+            modalBtnSunat.style.display = 'inline-block';
+        } else if (selectedOptionText === 'DNI') {
+            modalLabelNombres.textContent = 'Nombres:';
+            modalGroupApellidos.style.display = 'block';
+            modalBtnSunat.style.display = 'inline-block';
         } else {
             modalLabelNombres.textContent = 'Nombres:';
             modalGroupApellidos.style.display = 'block';
+            modalBtnSunat.style.display = 'none';
         }
+    });
+
+    // --- Lógica del Botón Sunat en Modal ---
+    modalBtnSunat.addEventListener('click', function() {
+        const numero = modalInputDocumento.value.trim();
+        const tipoDocText = modalTipoDocumento.options[modalTipoDocumento.selectedIndex].text.trim().toUpperCase();
+
+        if ((tipoDocText === 'DNI' && numero.length !== 8) || (tipoDocText === 'RUC' && numero.length !== 11)) {
+            alert(`El número de ${tipoDocText} debe tener ${tipoDocText === 'DNI' ? 8 : 11} dígitos.`);
+            return;
+        }
+
+        let apiUrl = '';
+        if (tipoDocText === 'DNI') {
+            apiUrl = `https://api.apis.net.pe/v1/dni?numero=${numero}`;
+        } else if (tipoDocText === 'RUC') {
+            apiUrl = `https://api.apis.net.pe/v1/ruc?numero=${numero}`;
+        } else {
+            return;
+        }
+
+        this.textContent = '...';
+        this.disabled = true;
+
+        fetch(apiUrl)
+            .then(response => response.json())
+            .then(data => {
+                if (data.numeroDocumento) {
+                    if (tipoDocText === 'DNI') {
+                        modalInputNombres.value = data.nombres || '';
+                        modalInputApellidos.value = `${data.apellidoPaterno || ''} ${data.apellidoMaterno || ''}`.trim();
+                    } else if (tipoDocText === 'RUC') {
+                        modalInputNombres.value = data.nombre || '';
+                        modalInputDireccion.value = data.direccion || '';
+                        modalInputUbigeo.value = data.ubigeo || '';
+                    }
+                } else {
+                    alert('No se encontraron datos para el documento ingresado.');
+                }
+            })
+            .catch(error => {
+                console.error('Error en la consulta a la API:', error);
+                alert('Ocurrió un error al consultar el servicio.');
+            })
+            .finally(() => {
+                this.textContent = 'Sunat';
+                this.disabled = false;
+            });
     });
 
     modalInputDocumento.addEventListener('keyup', function() {
@@ -126,27 +184,21 @@ document.addEventListener('DOMContentLoaded', function() {
     formNuevoCliente.addEventListener('submit', function(e) {
         e.preventDefault();
         modalErrorMessage.style.display = 'none';
-
         if (modalSubmitBtn.disabled) {
             modalErrorMessage.textContent = 'Por favor, corrija los errores antes de continuar.';
             modalErrorMessage.style.display = 'block';
             return;
         }
-
         const selectedOptionText = modalTipoDocumento.options[modalTipoDocumento.selectedIndex].text.trim().toUpperCase();
-
-        // --- Validación de Apellidos ---
         if (selectedOptionText !== 'RUC' && modalInputApellidos.value.trim() === '') {
             modalErrorMessage.textContent = 'El campo Apellidos es obligatorio para este tipo de documento.';
             modalErrorMessage.style.display = 'block';
             return;
         }
-
         const formData = new FormData(this);
         if (selectedOptionText === 'RUC') {
             formData.set('apellidos', '');
         }
-
         fetch('index.php?view=clientes&action=crear_ajax', {
             method: 'POST',
             body: formData

--- a/views/clientes/form.php
+++ b/views/clientes/form.php
@@ -38,7 +38,10 @@ $action_url = $is_edit ? 'index.php?view=clientes&action=update' : 'index.php?vi
             </div>
             <div class="form-group">
                 <label for="numero_documento">Número de Documento:</label>
-                <input type="text" id="numero_documento" name="numero_documento" value="<?php echo htmlspecialchars($cliente_a_editar['numero_documento'] ?? ''); ?>" required>
+                <div class="input-with-button">
+                    <input type="text" id="numero_documento" name="numero_documento" value="<?php echo htmlspecialchars($cliente_a_editar['numero_documento'] ?? ''); ?>" required>
+                    <button type="button" id="btn_sunat" class="btn btn-info" style="display: none;">Sunat</button>
+                </div>
                 <div id="documento-error" class="validation-error" style="display: none; color: red; font-size: 0.9em;"></div>
             </div>
         </div>

--- a/views/matriculas/nueva.php
+++ b/views/matriculas/nueva.php
@@ -155,7 +155,10 @@
                 </div>
                 <div class="form-group">
                     <label for="modal_numero_documento">Número de Documento:</label>
-                    <input type="text" id="modal_numero_documento" name="numero_documento" required>
+                    <div class="input-with-button">
+                        <input type="text" id="modal_numero_documento" name="numero_documento" required>
+                        <button type="button" id="btn_sunat_modal" class="btn btn-info" style="display: none;">Sunat</button>
+                    </div>
                     <div id="modal-documento-error" class="validation-error-modal" style="display: none;"></div>
                 </div>
             </div>


### PR DESCRIPTION
This commit adds a 'Sunat' button to the client creation forms (both the main page and the enrollment modal). This feature allows users to fetch client data from an external API (apis.net.pe) using a DNI or RUC number.

- A 'Sunat' button is now visible next to the document number field when the document type is 'DNI' or 'RUC'.
- A click event listener on the button triggers a JavaScript `fetch` call to the appropriate API endpoint.
- Upon a successful API response, the form fields are auto-populated:
  - For DNI: 'Nombres' and 'Apellidos' are filled.
  - For RUC: 'Razón Social' (the 'Nombres' field), 'Dirección', and 'Código de Ubigeo' are filled.
- This functionality is implemented in both `public/assets/js/cliente_form.js` for the main form and `public/assets/js/matricula_form.js` for the modal, ensuring a consistent user experience.