### PR TITLE
fix(clientes): Correct API data mapping for Sunat integration

### DIFF
--- a/public/assets/js/cliente_form.js
+++ b/public/assets/js/cliente_form.js
@@ -101,11 +101,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 .then(data => {
                     if (data.numeroDocumento) {
                         if (tipoDocText === 'DNI') {
-                            inputNombres.value = data.nombres || '';
+                            inputNombres.value = data.nombre || ''; // Nombre completo
                             inputApellidos.value = `${data.apellidoPaterno || ''} ${data.apellidoMaterno || ''}`.trim();
                         } else if (tipoDocText === 'RUC') {
-                            inputNombres.value = data.nombre || '';
-                            inputDireccion.value = data.direccion || '';
+                            inputNombres.value = data.nombre || ''; // Razón Social
+                            const fullAddress = `${data.direccion || ''} - ${data.departamento || ''} - ${data.provincia || ''} - ${data.distrito || ''}`.trim();
+                            inputDireccion.value = fullAddress.replace(/^-| -$/g, '').replace(/ - - /g, ' - ');
                             inputUbigeo.value = data.ubigeo || '';
                         }
                     } else {

--- a/public/assets/js/matricula_form.js
+++ b/public/assets/js/matricula_form.js
@@ -139,11 +139,12 @@ document.addEventListener('DOMContentLoaded', function() {
             .then(data => {
                 if (data.numeroDocumento) {
                     if (tipoDocText === 'DNI') {
-                        modalInputNombres.value = data.nombres || '';
+                            modalInputNombres.value = data.nombre || ''; // Nombre completo
                         modalInputApellidos.value = `${data.apellidoPaterno || ''} ${data.apellidoMaterno || ''}`.trim();
                     } else if (tipoDocText === 'RUC') {
-                        modalInputNombres.value = data.nombre || '';
-                        modalInputDireccion.value = data.direccion || '';
+                            modalInputNombres.value = data.nombre || ''; // Razón Social
+                            const fullAddress = `${data.direccion || ''} - ${data.departamento || ''} - ${data.provincia || ''} - ${data.distrito || ''}`.trim();
+                            modalInputDireccion.value = fullAddress.replace(/^-| -$/g, '').replace(/ - - /g, ' - ');
                         modalInputUbigeo.value = data.ubigeo || '';
                     }
                 } else {


### PR DESCRIPTION
This commit corrects the logic for populating form fields from the Sunat API response, based on detailed user specifications.

- For DNI lookups, the 'Nombres' field is now populated with the full name (`nombre` from the API), and 'Apellidos' is a concatenation of `apellidoPaterno` and `apellidoMaterno`.
- For RUC lookups, the 'Dirección' field is now a full, concatenated address including a department, province, and district from the API response.

This ensures the auto-populated data precisely matches the user's requirements for both document types. The changes have been applied to both the main client form and the new client modal.