### PR TITLE
fix(js): Add cache-busting to JS includes

### DIFF
--- a/views/clientes/form.php
+++ b/views/clientes/form.php
@@ -91,7 +91,7 @@ $action_url = $is_edit ? 'index.php?view=clientes&action=update' : 'index.php?vi
     </form>
 </div>
 
-<!-- Incluir el nuevo archivo JS -->
-<script src="public/assets/js/cliente_form.js"></script>
+<!-- Incluir el nuevo archivo JS con cache-busting -->
+<script src="public/assets/js/cliente_form.js?v=<?php echo time(); ?>"></script>
 
 <?php require_once 'views/partials/footer.php'; ?>

--- a/views/matriculas/nueva.php
+++ b/views/matriculas/nueva.php
@@ -207,6 +207,6 @@
 <script>
     const matriculaDetalles = [];
 </script>
-<script src="<?php echo $base_url; ?>public/assets/js/matricula_form.js"></script>
+<script src="<?php echo $base_url; ?>public/assets/js/matricula_form.js?v=<?php echo time(); ?>"></script>
 
 <?php require_once 'views/partials/footer.php'; ?>


### PR DESCRIPTION
This commit adds a cache-busting query parameter to the JavaScript file includes for `cliente_form.js` and `matricula_form.js`.

This is to ensure that users' browsers always download the latest version of the scripts, preventing issues where old, cached files were causing persistent errors (like CORS errors) even after a server-side fix had been deployed.

A dynamic timestamp (`?v=<?php echo time(); ?>`) is appended to the script URLs to guarantee a fresh version is loaded on each page view.