### PR TITLE
style(dashboard): Increase size of pie charts

### DIFF
--- a/views/dashboard/dashboard_view.php
+++ b/views/dashboard/dashboard_view.php
@@ -61,7 +61,7 @@
 .chart-container-pie {
     position: relative;
     margin: auto;
-    max-width: 250px; /* Tamaño reducido */
+    max-width: 315px; /* Tamaño ajustado (25% más grande que 250px) */
 }
 </style>
 


### PR DESCRIPTION
This commit increases the size of the two pie charts on the dashboard by approximately 25%, as requested by the user.

The `max-width` of the `.chart-container-pie` CSS class has been adjusted from 250px to 315px to make the charts larger and more readable.