### PR TITLE
style(dashboard): Enlarge and align pie charts

### DIFF
--- a/views/dashboard/dashboard_view.php
+++ b/views/dashboard/dashboard_view.php
@@ -60,8 +60,9 @@
 }
 .chart-container-pie {
     position: relative;
-    margin: auto;
-    max-width: 315px; /* Tamaño ajustado (25% más grande que 250px) */
+    margin-left: 0; /* Alinear a la izquierda */
+    margin-right: auto;
+    max-width: 400px; /* Aumentado otro 25% */
 }
 </style>
 


### PR DESCRIPTION
This commit applies final style adjustments to the dashboard pie charts based on user feedback.

- The `max-width` of the pie chart containers has been increased by another 25% (to 400px) to make them more prominent.
- The charts are now aligned to the left within their grid containers (`margin-left: 0`) to provide more space for the legend on the right, ensuring the legend text is fully visible and not truncated.