### PR TITLE
style(dashboard): Revert pie chart size to smaller dimension

### DIFF
--- a/views/dashboard/dashboard_view.php
+++ b/views/dashboard/dashboard_view.php
@@ -60,9 +60,8 @@
 }
 .chart-container-pie {
     position: relative;
-    margin-left: 0;
-    margin-right: auto;
-    max-width: 400px;
+    margin: auto; /* Centrar el contenedor */
+    max-width: 250px; /* Tamaño reducido original */
 }
 </style>
 


### PR DESCRIPTION
This commit reverts the size of the pie charts on the dashboard to a smaller dimension as per the user's final request.

The `max-width` of the `.chart-container-pie` CSS class has been changed back to 250px and centered. The legend text readability is maintained by the previously implemented text-wrapping logic, which ensures labels are fully visible even in the smaller container.