### PR TITLE
feat(dashboard): Replace monthly sales chart with stacked bar chart

### DIFF
--- a/bd/update_v1.35_stacked_bar_chart.sql
+++ b/bd/update_v1.35_stacked_bar_chart.sql
@@ -1,0 +1,43 @@
+-- =================================================================
+-- Script de Actualización de la Base de Datos - Versión 1.35
+-- Añade SP para el gráfico de barras apiladas del dashboard.
+-- =================================================================
+
+USE `academia_cursos`;
+
+DELIMITER $$
+
+-- -----------------------------------------------------
+-- `sp_dashboard_ventas_anuales_por_mes_y_curso`
+-- Obtiene las ventas de un año específico, agrupado
+-- por mes y por curso para el gráfico de barras apiladas.
+-- -----------------------------------------------------
+
+DROP PROCEDURE IF EXISTS `sp_dashboard_ventas_anuales_por_mes_y_curso`$$
+CREATE PROCEDURE `sp_dashboard_ventas_anuales_por_mes_y_curso`(
+    IN p_anio INT
+)
+BEGIN
+    SELECT
+        MONTH(m.fecha_matricula) AS `mes`,
+        c.nombre AS `nombre_curso`,
+        SUM(md.precio_final) AS `total_ventas`
+    FROM matriculas m
+    JOIN matriculas_detalle md ON m.id_matricula = md.id_matricula
+    JOIN cursos_programados cp ON md.id_curso_programado = cp.id_curso_programado
+    JOIN cursos c ON cp.id_curso = c.id_curso
+    WHERE
+        YEAR(m.fecha_matricula) = p_anio
+        AND m.estado = 'Activa'
+    GROUP BY
+        `mes`,
+        `nombre_curso`
+    ORDER BY
+        `mes`,
+        `nombre_curso`;
+END$$
+
+-- También se necesita eliminar el SP antiguo que ya no se usará
+DROP PROCEDURE IF EXISTS `sp_dashboard_ventas_mensuales`$$
+
+DELIMITER ;

--- a/controllers/dashboard_controller.php
+++ b/controllers/dashboard_controller.php
@@ -4,56 +4,68 @@
 // Controlador para el Panel Principal (Dashboard)
 // =================================================================
 
-// Primero, verificar que el usuario tenga una sesión activa.
-// Si no, la clase Session lo redirigirá al login.
 Session::check();
 
-// Aquí iría la lógica para obtener los datos de los gráficos, etc.
-// Por ahora, solo cargamos la vista.
-
-$nombre_usuario = $_SESSION['user_fullname'];
-
-
-// Cargar el modelo del dashboard
 require_once 'models/DashboardModel.php';
 $dashboardModel = new DashboardModel();
 
 // --- Lógica de Filtros ---
 $anio_seleccionado = $_GET['anio'] ?? date('Y');
 $mes_seleccionado = $_GET['mes'] ?? date('m');
+$meses_nombres = ["Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"];
 
-// --- Obtención de datos para los gráficos ---
+// --- Obtención de datos para los gráficos circulares (sin cambios) ---
 $ventas_por_curso_data = $dashboardModel->getVentasPorCurso($anio_seleccionado, $mes_seleccionado);
-$ventas_mensuales_data = $dashboardModel->getVentasMensuales($anio_seleccionado);
+$ventas_por_curso_area_data = $dashboardModel->getVentasPorCursoArea($anio_seleccionado, $mes_seleccionado);
 
-// Preparar los datos para que JavaScript los pueda usar fácilmente
 $chart_data_pie = [
     'labels' => array_column($ventas_por_curso_data, 'nombre_curso'),
     'data' => array_column($ventas_por_curso_data, 'total_ventas')
 ];
-
-// Para el gráfico de barras, necesitamos asegurarnos de que todos los meses estén presentes
-$ventas_barras_raw = array_column($ventas_mensuales_data, 'total_ventas', 'mes');
-$chart_data_bar = [
-    'labels' => ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'],
-    'data' => []
-];
-for ($i = 1; $i <= 12; $i++) {
-    $chart_data_bar['data'][] = $ventas_barras_raw[$i] ?? 0;
-}
-
-
-// --- Obtención de datos para el tercer gráfico ---
-$ventas_por_curso_area_data = $dashboardModel->getVentasPorCursoArea($anio_seleccionado, $mes_seleccionado);
 $chart_data_pie_area = [
     'labels' => array_column($ventas_por_curso_area_data, 'label'),
     'data' => array_column($ventas_por_curso_area_data, 'total_ventas')
 ];
 
-// Convertir los datos a JSON para inyectarlos en el script de la vista
+// --- Obtención y procesamiento de datos para el gráfico de barras apiladas ---
+$ventas_anuales_raw = $dashboardModel->getVentasAnualesPorCurso($anio_seleccionado);
+
+// 1. Agrupar datos por curso
+$datos_por_curso = [];
+foreach ($ventas_anuales_raw as $fila) {
+    $datos_por_curso[$fila['nombre_curso']][$fila['mes']] = $fila['total_ventas'];
+}
+
+// 2. Construir la estructura de datasets para Chart.js
+$datasets_barras = [];
+$colores_cursos = ['#007bff', '#28a745', '#ffc107', '#dc3545', '#6f42c1', '#fd7e14', '#20c997', '#6610f2', '#e83e8c', '#17a2b8'];
+$color_index = 0;
+
+foreach ($datos_por_curso as $curso => $ventas_mes) {
+    $datos_mes_completo = [];
+    for ($i = 1; $i <= 12; $i++) {
+        $datos_mes_completo[] = $ventas_mes[$i] ?? 0;
+    }
+
+    $datasets_barras[] = [
+        'label' => $curso,
+        'data' => $datos_mes_completo,
+        'backgroundColor' => $colores_cursos[$color_index % count($colores_cursos)]
+    ];
+    $color_index++;
+}
+
+// 3. Estructura final para el gráfico de barras
+$chart_data_bar = [
+    'labels' => ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'],
+    'datasets' => $datasets_barras
+];
+
+
+// --- Convertir todos los datos a JSON para la vista ---
 $json_data_pie = json_encode($chart_data_pie);
-$json_data_bar = json_encode($chart_data_bar);
 $json_data_pie_area = json_encode($chart_data_pie_area);
+$json_data_bar = json_encode($chart_data_bar);
 
 
 // Cargar la vista del dashboard

--- a/models/DashboardModel.php
+++ b/models/DashboardModel.php
@@ -23,12 +23,12 @@ class DashboardModel {
     }
 
     /**
-     * Obtiene los datos de ventas mensuales para un año.
+     * Obtiene los datos de ventas anuales desglosado por mes y curso.
      * @param int $anio
      * @return array
      */
-    public function getVentasMensuales($anio) {
-        $this->db->callStoredProcedure('sp_dashboard_ventas_mensuales', [$anio]);
+    public function getVentasAnualesPorCurso($anio) {
+        $this->db->callStoredProcedure('sp_dashboard_ventas_anuales_por_mes_y_curso', [$anio]);
         return $this->db->resultSet();
     }
 

--- a/views/dashboard/dashboard_view.php
+++ b/views/dashboard/dashboard_view.php
@@ -124,12 +124,21 @@ document.addEventListener('DOMContentLoaded', function() {
     // --- Gráfico de Barras: Ventas Mensuales ---
     const barCtx = document.getElementById('barChartVentas').getContext('2d');
     const barData = <?php echo $json_data_bar; ?>;
-    new Chart(barCtx, { type: 'bar', data: { labels: barData.labels, datasets: [{
-        label: 'Ventas Totales', data: barData.data,
-        backgroundColor: 'rgba(0, 123, 255, 0.7)',
-        borderColor: 'rgba(0, 123, 255, 1)',
-        borderWidth: 1
-    }]}, options: { scales: { y: { beginAtZero: true } }, plugins: { legend: { display: true }, datalabels: { display: false } } }});
+    new Chart(barCtx, {
+        type: 'bar',
+        data: barData, // La nueva estructura ya tiene 'labels' y 'datasets'
+        options: {
+            plugins: {
+                title: { display: false },
+                legend: { display: true, position: 'top' } // Habilitar leyenda
+            },
+            responsive: true,
+            scales: {
+                x: { stacked: true }, // Apilar en el eje X
+                y: { stacked: true, beginAtZero: true } // Apilar en el eje Y
+            }
+        }
+    });
 
     // --- Gráfico Circular 1: Ventas por Curso ---
     const pieCtx = document.getElementById('pieChartVentas').getContext('2d');


### PR DESCRIPTION
This commit replaces the simple monthly sales bar chart with a more informative stacked bar chart that breaks down sales by course for each month of the selected year.

- A new stored procedure, `sp_dashboard_ventas_anuales_por_mes_y_curso`, has been created to fetch the detailed sales data.
- The `DashboardController` now contains logic to pivot this data into the nested structure required by Chart.js for stacked datasets.
- The `dashboard_view` has been updated to configure the bar chart as a stacked bar chart (`stacked: true`) and to display a legend with the course names and their corresponding colors.
- The old, unused stored procedure for the simple bar chart has been removed.