### PR TITLE
feat(clientes): Add status field to client management

### DIFF
--- a/bd/stored_procedures_clientes.sql
+++ b/bd/stored_procedures_clientes.sql
@@ -20,7 +20,10 @@ BEGIN
         td.descripcion AS tipo_documento,
         c.numero_documento,
         c.email,
-        c.telefono
+        c.telefono,
+        c.direccion,
+        c.codigo_ubigeo,
+        c.estado
     FROM clientes c
     JOIN tipos_documento td ON c.id_tipo_documento = td.id_tipo_documento
     ORDER BY c.apellidos, c.nombres;
@@ -41,7 +44,8 @@ BEGIN
         td.descripcion AS tipo_documento,
         c.numero_documento,
         c.email,
-        c.telefono
+        c.telefono,
+        c.estado
     FROM clientes c
     JOIN tipos_documento td ON c.id_tipo_documento = td.id_tipo_documento
     WHERE c.nombres LIKE @termino_busqueda
@@ -65,7 +69,10 @@ BEGIN
         apellidos,
         email,
         telefono,
-        codigo_erp
+        codigo_erp,
+        direccion,
+        codigo_ubigeo,
+        estado
     FROM clientes
     WHERE id_cliente = p_id_cliente;
 END$$
@@ -82,7 +89,10 @@ CREATE PROCEDURE `sp_clientes_crear`(
     IN p_apellidos VARCHAR(100),
     IN p_email VARCHAR(100),
     IN p_telefono VARCHAR(20),
-    IN p_codigo_erp VARCHAR(20)
+    IN p_codigo_erp VARCHAR(20),
+    IN p_direccion VARCHAR(255),
+    IN p_codigo_ubigeo VARCHAR(10),
+    IN p_estado ENUM('Activado', 'Desactivado')
 )
 BEGIN
     DECLARE cliente_existente INT;
@@ -94,8 +104,8 @@ BEGIN
     IF cliente_existente > 0 THEN
         SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Ya existe un cliente con el mismo tipo y número de documento.';
     ELSE
-        INSERT INTO clientes (id_tipo_documento, numero_documento, nombres, apellidos, email, telefono, codigo_erp)
-        VALUES (p_id_tipo_documento, p_numero_documento, p_nombres, p_apellidos, p_email, p_telefono, p_codigo_erp);
+        INSERT INTO clientes (id_tipo_documento, numero_documento, nombres, apellidos, email, telefono, codigo_erp, direccion, codigo_ubigeo, estado)
+        VALUES (p_id_tipo_documento, p_numero_documento, p_nombres, p_apellidos, p_email, p_telefono, p_codigo_erp, p_direccion, p_codigo_ubigeo, p_estado);
         SELECT LAST_INSERT_ID() as id_cliente;
     END IF;
 END$$
@@ -113,7 +123,10 @@ CREATE PROCEDURE `sp_clientes_actualizar`(
     IN p_apellidos VARCHAR(100),
     IN p_email VARCHAR(100),
     IN p_telefono VARCHAR(20),
-    IN p_codigo_erp VARCHAR(20)
+    IN p_codigo_erp VARCHAR(20),
+    IN p_direccion VARCHAR(255),
+    IN p_codigo_ubigeo VARCHAR(10),
+    IN p_estado ENUM('Activado', 'Desactivado')
 )
 BEGIN
     DECLARE cliente_existente INT;
@@ -133,7 +146,10 @@ BEGIN
             apellidos = p_apellidos,
             email = p_email,
             telefono = p_telefono,
-            codigo_erp = p_codigo_erp
+            codigo_erp = p_codigo_erp,
+            direccion = p_direccion,
+            codigo_ubigeo = p_codigo_ubigeo,
+            estado = p_estado
         WHERE id_cliente = p_id_cliente;
     END IF;
 END$$

--- a/bd/update_v1.36_add_cliente_estado.sql
+++ b/bd/update_v1.36_add_cliente_estado.sql
@@ -1,0 +1,14 @@
+-- =================================================================
+-- Update Script v1.36
+-- Description: Adds the 'estado' column to the 'clientes' table.
+-- =================================================================
+
+ALTER TABLE `clientes`
+ADD COLUMN `estado` ENUM('Activado', 'Desactivado') NOT NULL DEFAULT 'Activado' COMMENT 'Estado del cliente: Activado o Desactivado' AFTER `codigo_erp`;
+
+-- =================================================================
+-- Update Stored Procedures related to clients
+-- =================================================================
+
+-- Note: The full definitions of the updated stored procedures are in 'stored_procedures_clientes.sql'.
+-- This note is for context. The actual changes will be applied directly to that file.

--- a/controllers/clientes_controller.php
+++ b/controllers/clientes_controller.php
@@ -41,6 +41,7 @@ try {
                     'email' => $_POST['email'],
                     'telefono' => $_POST['telefono'],
                     'codigo_erp' => $_POST['codigo_erp'],
+                    'estado' => $_POST['estado'],
                     'direccion' => $_POST['direccion'],
                     'codigo_ubigeo' => $_POST['codigo_ubigeo']
                 ];
@@ -68,6 +69,7 @@ try {
                     'email' => $_POST['email'],
                     'telefono' => $_POST['telefono'],
                     'codigo_erp' => $_POST['codigo_erp'],
+                    'estado' => $_POST['estado'],
                     'direccion' => $_POST['direccion'],
                     'codigo_ubigeo' => $_POST['codigo_ubigeo']
                 ];

--- a/models/ClienteModel.php
+++ b/models/ClienteModel.php
@@ -43,7 +43,8 @@ class ClienteModel {
             $datos['telefono'],
             $datos['codigo_erp'],
             $datos['direccion'],
-            $datos['codigo_ubigeo']
+            $datos['codigo_ubigeo'],
+            $datos['estado']
         ];
         try {
             $this->db->callStoredProcedure('sp_clientes_crear', $params);
@@ -80,7 +81,8 @@ class ClienteModel {
             $datos['telefono'],
             $datos['codigo_erp'],
             $datos['direccion'],
-            $datos['codigo_ubigeo']
+            $datos['codigo_ubigeo'],
+            $datos['estado']
         ];
         try {
             $this->db->callStoredProcedure('sp_clientes_actualizar', $params);

--- a/views/clientes/form.php
+++ b/views/clientes/form.php
@@ -79,9 +79,18 @@ $action_url = $is_edit ? 'index.php?view=clientes&action=update' : 'index.php?vi
             </div>
         </div>
 
-        <div class="form-group">
-            <label for="codigo_erp">Código ERP:</label>
-            <input type="text" id="codigo_erp" name="codigo_erp" value="<?php echo htmlspecialchars($cliente_a_editar['codigo_erp'] ?? ''); ?>">
+        <div class="form-row">
+            <div class="form-group">
+                <label for="estado">Estado:</label>
+                <select id="estado" name="estado" required>
+                    <option value="Activado" <?php echo (isset($cliente_a_editar) && $cliente_a_editar['estado'] == 'Activado') ? 'selected' : ''; ?>>Activado</option>
+                    <option value="Desactivado" <?php echo (isset($cliente_a_editar) && $cliente_a_editar['estado'] == 'Desactivado') ? 'selected' : ''; ?>>Desactivado</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="codigo_erp">Código ERP:</label>
+                <input type="text" id="codigo_erp" name="codigo_erp" value="<?php echo htmlspecialchars($cliente_a_editar['codigo_erp'] ?? ''); ?>">
+            </div>
         </div>
 
         <div class="form-actions">

--- a/views/clientes/list.php
+++ b/views/clientes/list.php
@@ -32,6 +32,7 @@
             <th>Documento</th>
             <th>Email</th>
             <th>Teléfono</th>
+            <th>Estado</th>
             <th>Dirección</th>
             <th>Ubigeo</th>
             <th>Acciones</th>
@@ -50,6 +51,7 @@
                     <td><?php echo htmlspecialchars($cliente['tipo_documento']) . ': ' . htmlspecialchars($cliente['numero_documento']); ?></td>
                     <td><?php echo htmlspecialchars($cliente['email']); ?></td>
                     <td><?php echo htmlspecialchars($cliente['telefono']); ?></td>
+                    <td><span class="status-<?php echo strtolower($cliente['estado']); ?>"><?php echo htmlspecialchars($cliente['estado']); ?></span></td>
                     <td><?php echo htmlspecialchars($cliente['direccion'] ?? ''); ?></td>
                     <td><?php echo htmlspecialchars($cliente['codigo_ubigeo'] ?? ''); ?></td>
                     <td>


### PR DESCRIPTION
Adds a new "estado" (status) field to the client entity, allowing users to set a client's status to "Activado" or "Desactivado".

This change includes:
- A database migration to add the `estado` column to the `clientes` table.
- Updates to the `crear`, `actualizar`, `listar`, `buscar`, and `obtener_por_id` stored procedures to handle the new field.
- Modifications to the `ClienteModel` and `clientes_controller` to support the new field in the backend logic.
- Updates to the client list and form views to display and manage the new status field in the user interface.